### PR TITLE
Remove empty lines on no verbosity

### DIFF
--- a/hyperactive/hyperactive.py
+++ b/hyperactive/hyperactive.py
@@ -136,8 +136,9 @@ class Hyperactive:
     def _print_info(self):
         print_res = PrintResults(self.opt_pros, self.verbosity)
 
-        for _ in range(len(self.opt_pros)):
-            print("")
+        if self.verbosity:
+            for _ in range(len(self.opt_pros)):
+                print("")
 
         for results in self.results_list:
             nth_process = results["nth_process"]


### PR DESCRIPTION
Clears final new lines on no-verbosity as in: #70

```
import numpy as np
from hyperactive import Hyperactive


def objective_function(para):
    x, y = para["x"], para["y"]

    return -(x * x + y * y)


search_space = {
    "x": list(np.arange(-10, 10, 0.01)),
    "y": list(np.arange(-10, 10, 0.01)),
}


#hyper = Hyperactive(verbosity=["print_results"])
hyper = Hyperactive(verbosity=False)
hyper.add_search(objective_function, search_space, n_iter=100)
hyper.run()
```

 With the edit, the verbosity of `False` doesn't add a new line, however, still enteres the for loop if e.g. `print_results` is enabled. 