### PR TITLE
[ENH] partial design sketch with experiment and optimizer base classes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
   "tqdm >=4.48.0, <5.0.0",
   "pandas <3.0.0",
   "gradient-free-optimizers >=1.2.4, <2.0.0",
+  "scikit-base <1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/src/hyperactive/base/__init__.py
+++ b/src/hyperactive/base/__init__.py
@@ -1,0 +1,6 @@
+"""Base classes for optimizers and experiments."""
+
+from hyperactive.base._experiment import BaseExperiment
+from hyperactive.base._optimizer import BaseOptimizer
+
+__all__ = ["BaseExperiment", "BaseOptimizer"]

--- a/src/hyperactive/base/_experiment.py
+++ b/src/hyperactive/base/_experiment.py
@@ -1,0 +1,71 @@
+"""Base class for experiment."""
+
+from skbase.base import BaseObject
+
+
+class BaseExperiment(BaseObject):
+    """Base class for experiment."""
+
+    def __init__(self):
+        super().__init__()
+
+    def __call__(self, **kwargs):
+        """Score parameters, with kwargs call."""
+        return self.score(kwargs)
+
+    def paramnames(self):
+        """Return the parameter names of the search.
+
+        Returns
+        -------
+        list of str
+            The parameter names of the search parameters.
+        """
+        return self._paramnames()
+
+    def _paramnames(self):
+        """Return the parameter names of the search.
+
+        Returns
+        -------
+        list of str
+            The parameter names of the search parameters.
+        """
+        raise NotImplementedError
+
+    def score(self, **params):
+        """Score the parameters.
+
+        Parameters
+        ----------
+        params : dict with string keys
+            Parameters to score.
+
+        Returns
+        -------
+        float
+            The score of the parameters.
+        dict
+            Additional metadata about the search.
+        """
+        paramnames = self.paramnames()
+        if not set(paramnames) == set(params.keys()):
+            raise ValueError("Parameters do not match.")
+        return self._score(**params)
+
+    def _score(self, **params):
+        """Score the parameters.
+
+        Parameters
+        ----------
+        params : dict with string keys
+            Parameters to score.
+
+        Returns
+        -------
+        float
+            The score of the parameters.
+        dict
+            Additional metadata about the search.
+        """
+        raise NotImplementedError

--- a/src/hyperactive/base/_optimizer.py
+++ b/src/hyperactive/base/_optimizer.py
@@ -1,0 +1,33 @@
+"""Base class for optimizer."""
+
+from skbase.base import BaseObject
+
+
+class BaseOptimizer(BaseObject):
+    """Base class for optimizer."""
+
+    def __init__(self):
+        super().__init__()
+
+    def add_search(self, experiment, search_config: dict):
+        """Add a new optimization search process with specified parameters.
+
+        Parameters
+        ----------
+        experiment : BaseExperiment
+            The experiment to optimize parameters for.
+        search_config : dict with str keys
+            The search configuration dictionary.
+        """
+        self.experiment = experiment
+        self.search_config = search_config
+
+    def run(self, max_time=None):
+        """Run the optimization search process.
+
+        Parameters
+        ----------
+        max_time : float
+            The maximum time used for the optimization process.
+        """
+        raise NotImplementedError

--- a/src/hyperactive/integrations/sklearn/hyperactive_search_cv.py
+++ b/src/hyperactive/integrations/sklearn/hyperactive_search_cv.py
@@ -18,6 +18,7 @@ from .objective_function_adapter import ObjectiveFunctionAdapter
 from .best_estimator import BestEstimator as _BestEstimator_
 from .checks import Checks
 from ...optimizers import RandomSearchOptimizer
+from hyperactive.integrations.sklearn.sklearn_cv_experiment import SklearnCvExperiment
 
 
 class HyperactiveSearchCV(BaseEstimator, _BestEstimator_, Checks):
@@ -118,12 +119,14 @@ class HyperactiveSearchCV(BaseEstimator, _BestEstimator_, Checks):
         fit_params = _check_method_params(X, params=fit_params)
         self.scorer_ = check_scoring(self.estimator, scoring=self.scoring)
 
-        objective_function_adapter = ObjectiveFunctionAdapter(
-            self.estimator,
+        experiment = SklearnCvExperiment(
+            estimator=self.estimator,
+            scoring=self.scorer_,
+            cv=self.cv,
+            X=X,
+            y=y,
         )
-        objective_function_adapter.add_dataset(X, y)
-        objective_function_adapter.add_validation(self.scorer_, self.cv)
-        objective_function = objective_function_adapter.objective_function
+        objective_function = experiment.score
 
         hyper = Hyperactive(verbosity=False)
         hyper.add_search(

--- a/src/hyperactive/integrations/sklearn/sklearn_cv_experiment.py
+++ b/src/hyperactive/integrations/sklearn/sklearn_cv_experiment.py
@@ -6,7 +6,7 @@ from sklearn.utils.validation import _num_samples
 
 from hyperactive.base import BaseExperiment
 
-class BaseExperiment(BaseExperiment):
+class SklearnCvExperiment(BaseExperiment):
 
     def __init__(self, estimator, scoring, cv, X, y):
         self.estimator = estimator

--- a/src/hyperactive/integrations/sklearn/sklearn_cv_experiment.py
+++ b/src/hyperactive/integrations/sklearn/sklearn_cv_experiment.py
@@ -1,0 +1,59 @@
+"""Experiment adapter for sklearn cross-validation experiments."""
+
+from sklearn import clone
+from sklearn.model_selection import cross_validate
+from sklearn.utils.validation import _num_samples
+
+from hyperactive.base import BaseExperiment
+
+class BaseExperiment(BaseExperiment):
+
+    def __init__(self, estimator, scoring, cv, X, y):
+        self.estimator = estimator
+        self.X = X
+        self.y = y
+        self.scoring = scoring
+        self.cv = cv
+
+    def _paramnames(self):
+        """Return the parameter names of the search.
+
+        Returns
+        -------
+        list of str
+            The parameter names of the search parameters.
+        """
+        return list(self.estimator.get_params().keys())
+
+    def _score(self, **params):
+        """Score the parameters.
+
+        Parameters
+        ----------
+        params : dict with string keys
+            Parameters to score.
+
+        Returns
+        -------
+        float
+            The score of the parameters.
+        dict
+            Additional metadata about the search.
+        """
+        estimator = clone(self.estimator)
+        estimator.set_params(**params)
+
+        cv_results = cross_validate(
+            self.estimator,
+            self.X,
+            self.y,
+            cv=self.cv,
+        )
+
+        add_info_d = {
+            "score_time": cv_results["score_time"],
+            "fit_time": cv_results["fit_time"],
+            "n_test_samples": _num_samples(self.X),
+        }
+
+        return cv_results["test_score"].mean(), add_info_d


### PR DESCRIPTION
I have partially worked out the design for a flexible composition interface using experiment and optimizer base classes, see issue https://github.com/SimonBlanke/Hyperactive/issues/93 for a high-level explanation.

The idea is to combine flexibly abstract optimization/tuning algorithms with concrete optimization problems.

When carried out, we need to implement only once:

* concrete tuners/optimizers
* interfaces or integrations with packages like `sktime` or `sklearn`

For instance, implementing grid search, random search, and `optuna` search would immediately make these available to `sktime` forecasting tuning, if a forecasting integration is also implemented.

The example paritally refactors the current `sklearn` integration class as an experiment.

Please let me know if it is clear enough where this is going, or if you would like me to fill out more, e.g., until we have a full example working.

### completion steps

In the current code, as per this PR, the interaction of "experiment" and "optimizer" is isolated to the following blocks in the `sklearn` estimator's `fit`, which is "almost" the following:

```python

        experiment = SklearnCvExperiment(
            estimator=self.estimator,
            scoring=self.scorer_,
            cv=self.cv,
            X=X,
            y=y,
        )

        hyper = Hyperactive(verbosity=False)
        hyper.add_search(experiment, stuff)  # not quite but easy to refactor like this
        hyper.run()
```

From here, it would be only a small (but somewhat tedious) step to make `hyper` an abstract parameter of the class, which allows to plug in *any* search strategy as a `BaseOptimizer` class instance.

That would result in an `sklearn` class that could be used like this

`SearchCV(my_estimator, my_hyper, search_config)`