### PR TITLE
[BUG] fix non-use of `params` in `sklearn` adapter objective function

### DIFF
--- a/src/hyperactive/integrations/sklearn/objective_function_adapter.py
+++ b/src/hyperactive/integrations/sklearn/objective_function_adapter.py
@@ -3,6 +3,7 @@
 # License: MIT License
 
 
+from sklearn import clone
 from sklearn.model_selection import cross_validate
 from sklearn.utils.validation import _num_samples
 
@@ -20,8 +21,12 @@ class ObjectiveFunctionAdapter:
         self.cv = cv
 
     def objective_function(self, params):
+
+        estimator = clone(self.estimator)
+        estimator.set_params(**params)
+
         cv_results = cross_validate(
-            self.estimator,
+            estimator,
             self.X,
             self.y,
             cv=self.cv,


### PR DESCRIPTION
Fixes https://github.com/SimonBlanke/Hyperactive/issues/96 by adding a `set_params` and `clone` inside the objective function.