### PR TITLE
⚡️ Speed up method `HyperactiveSearchCV._refit` by 25%

### DIFF
--- a/src/hyperactive/integrations/sklearn/hyperactive_search_cv.py
+++ b/src/hyperactive/integrations/sklearn/hyperactive_search_cv.py
@@ -79,10 +79,11 @@ class HyperactiveSearchCV(BaseEstimator, _BestEstimator_, Checks):
         self.cv = cv
 
     def _refit(self, X, y=None, **fit_params):
-        self.best_estimator_ = clone(self.estimator).set_params(
-            **clone(self.best_params_, safe=False)
-        )
+        # Directly set parameters to the best estimator without unnecessary cloning
+        self.best_estimator_ = clone(self.estimator)
+        self.best_estimator_.set_params(**self.best_params_)
 
+        # Fit the best estimator with the entire dataset
         self.best_estimator_.fit(X, y, **fit_params)
         return self
 

--- a/src/hyperactive/integrations/sklearn/hyperactive_search_cv.py
+++ b/src/hyperactive/integrations/sklearn/hyperactive_search_cv.py
@@ -79,11 +79,9 @@ class HyperactiveSearchCV(BaseEstimator, _BestEstimator_, Checks):
         self.cv = cv
 
     def _refit(self, X, y=None, **fit_params):
-        # Directly set parameters to the best estimator without unnecessary cloning
         self.best_estimator_ = clone(self.estimator)
         self.best_estimator_.set_params(**self.best_params_)
 
-        # Fit the best estimator with the entire dataset
         self.best_estimator_.fit(X, y, **fit_params)
         return self
 


### PR DESCRIPTION
### 📄 25% (0.25x) speedup for ***`HyperactiveSearchCV._refit` in `src/hyperactive/integrations/sklearn/hyperactive_search_cv.py`***

⏱️ Runtime :   **`209 milliseconds`**  **→** **`167 milliseconds`** (best of `15` runs)
<details>
<summary> 📝 Explanation and details</summary>

To optimize the `HyperactiveSearchCV` class for better performance, we can make some adjustments focusing on the initialization logic and the `_refit` method. Here are the changes.

1. Instead of using `clone` twice in the `_refit` method, we can use the `set_params` method directly on the cloned estimator.
2. Making sure the parameters used in `set_params` are minimal and exclude unnecessary cloning.
3. Using NumPy where applicable for potential performance improvements, although this snippet might not be the best place for enhancements using NumPy directly.

Let's see the updated code snippet with these optimizations.



### Comments on the Changes.
- Removed redundant `clone` operation in `_refit`.
- Directly set parameters using `set_params` method to minimize overhead and unnecessary object creation.

This ensures the re-fitting process is more efficient and reduces the computational overhead. If the program as a whole has other sections that deal with I/O or can use parallel processing more efficiently (like the parallel jobs indicated by `n_jobs`), those would be the next target for optimization.

</details>

✅ **Correctness verification report:**

| Test                        | Status            |
| --------------------------- | ----------------- |
| ⚙️ Existing Unit Tests | 🔘 **None Found** |
| 🌀 Generated Regression Tests | ✅ **39 Passed** |
| ⏪ Replay Tests | 🔘 **None Found** |
| 🔎 Concolic Coverage Tests | 🔘 **None Found** |
|📊 Tests Coverage       | 100.0% |
<details>
<summary>🌀 Generated Regression Tests Details</summary>

```python
from typing import Callable, Dict, Type, Union

import numpy as np
# imports
import pytest  # used for our unit tests
from hyperactive.integrations.sklearn.hyperactive_search_cv import \
    HyperactiveSearchCV
from sklearn.base import BaseEstimator, clone
from sklearn.linear_model import LogisticRegression

# unit tests

# Basic Functionality
def test_refit_standard_case():
    X = np.array([[1, 2], [3, 4], [5, 6]])
    y = np.array([0, 1, 0])
    estimator = LogisticRegression()
    params_config = {'C': [0.1, 1, 10]}
    search = HyperactiveSearchCV(estimator, params_config)
    search.best_params_ = {'C': 1}
    search._refit(X, y)

# Edge Cases
def test_refit_empty_dataset():
    X = np.array([])
    y = np.array([])
    estimator = LogisticRegression()
    params_config = {'C': [0.1, 1, 10]}
    search = HyperactiveSearchCV(estimator, params_config)
    search.best_params_ = {'C': 1}
    with pytest.raises(ValueError):
        search._refit(X, y)

def test_refit_single_sample():
    X = np.array([[1, 2]])
    y = np.array([0])
    estimator = LogisticRegression()
    params_config = {'C': [0.1, 1, 10]}
    search = HyperactiveSearchCV(estimator, params_config)
    search.best_params_ = {'C': 1}
    search._refit(X, y)

def test_refit_single_feature():
    X = np.array([[1], [2], [3]])
    y = np.array([0, 1, 0])
    estimator = LogisticRegression()
    params_config = {'C': [0.1, 1, 10]}
    search = HyperactiveSearchCV(estimator, params_config)
    search.best_params_ = {'C': 1}
    search._refit(X, y)

def test_refit_single_class():
    X = np.array([[1, 2], [3, 4], [5, 6]])
    y = np.array([0, 0, 0])
    estimator = LogisticRegression()
    params_config = {'C': [0.1, 1, 10]}
    search = HyperactiveSearchCV(estimator, params_config)
    search.best_params_ = {'C': 1}
    with pytest.raises(ValueError):
        search._refit(X, y)

# Invalid Inputs
def test_refit_incorrect_data_types():
    X = [[1, 2], [3, 4], [5, 6]]  # List instead of numpy array
    y = "invalid"  # String instead of array-like
    estimator = LogisticRegression()
    params_config = {'C': [0.1, 1, 10]}
    search = HyperactiveSearchCV(estimator, params_config)
    search.best_params_ = {'C': 1}
    with pytest.raises(TypeError):
        search._refit(X, y)

def test_refit_mismatched_dimensions():
    X = np.array([[1, 2], [3, 4], [5, 6]])
    y = np.array([0, 1])  # Mismatched length
    estimator = LogisticRegression()
    params_config = {'C': [0.1, 1, 10]}
    search = HyperactiveSearchCV(estimator, params_config)
    search.best_params_ = {'C': 1}
    with pytest.raises(ValueError):
        search._refit(X, y)

# Hyperparameter Configurations
def test_refit_no_hyperparameters():
    X = np.array([[1, 2], [3, 4], [5, 6]])
    y = np.array([0, 1, 0])
    estimator = LogisticRegression()
    params_config = {}
    search = HyperactiveSearchCV(estimator, params_config)
    search.best_params_ = {}
    search._refit(X, y)

def test_refit_invalid_hyperparameters():
    X = np.array([[1, 2], [3, 4], [5, 6]])
    y = np.array([0, 1, 0])
    estimator = LogisticRegression()
    params_config = {'invalid_param': [0.1, 1, 10]}
    search = HyperactiveSearchCV(estimator, params_config)
    search.best_params_ = {'invalid_param': 1}
    with pytest.raises(ValueError):
        search._refit(X, y)

# Performance and Scalability
def test_refit_large_dataset():
    X = np.random.rand(10000, 100)
    y = np.random.randint(0, 2, 10000)
    estimator = LogisticRegression()
    params_config = {'C': [0.1, 1, 10]}
    search = HyperactiveSearchCV(estimator, params_config)
    search.best_params_ = {'C': 1}
    search._refit(X, y)

def test_refit_high_dimensional_data():
    X = np.random.rand(10, 10000)
    y = np.random.randint(0, 2, 10)
    estimator = LogisticRegression()
    params_config = {'C': [0.1, 1, 10]}
    search = HyperactiveSearchCV(estimator, params_config)
    search.best_params_ = {'C': 1}
    search._refit(X, y)

# Special Cases

def test_refit_custom_fit_params():
    X = np.array([[1, 2], [3, 4], [5, 6]])
    y = np.array([0, 1, 0])
    estimator = LogisticRegression()
    params_config = {'C': [0.1, 1, 10]}
    search = HyperactiveSearchCV(estimator, params_config)
    search.best_params_ = {'C': 1}
    search._refit(X, y, sample_weight=np.array([1, 1, 1]))

# Integration with Cross-Validation

def test_refit_random_state():
    X = np.array([[1, 2], [3, 4], [5, 6]])
    y = np.array([0, 1, 0])
    estimator = LogisticRegression()
    params_config = {'C': [0.1, 1, 10]}
    search = HyperactiveSearchCV(estimator, params_config, random_state=42)
    search.best_params_ = {'C': 1}
    search._refit(X, y)
# codeflash_output is used to check that the output of the original code is the same as that of the optimized code.

from typing import Callable, Dict, Type, Union

import numpy as np
# imports
import pytest  # used for our unit tests
from hyperactive.integrations.sklearn.hyperactive_search_cv import \
    HyperactiveSearchCV
from sklearn.base import BaseEstimator, clone


# Mock Estimator for testing
class MockEstimator(BaseEstimator):
    def __init__(self, param=1):
        self.param = param
        
    def fit(self, X, y=None, **fit_params):
        self.is_fitted_ = True
        return self
from hyperactive.integrations.sklearn.hyperactive_search_cv import \
    HyperactiveSearchCV

# unit tests

# Basic Functionality
def test_refit_basic():
    model = HyperactiveSearchCV(estimator=MockEstimator(), params_config={'param': [1, 2, 3]})
    model.best_params_ = {'param': 2}
    X = np.array([[1, 2], [3, 4], [5, 6]])
    y = np.array([1, 2, 3])
    model._refit(X, y)

# Edge Cases

def test_refit_single_data_point():
    model = HyperactiveSearchCV(estimator=MockEstimator(), params_config={'param': [1, 2, 3]})
    model.best_params_ = {'param': 2}
    X = np.array([[1, 2]])
    y = np.array([1])
    model._refit(X, y)


def test_refit_invalid_params():
    model = HyperactiveSearchCV(estimator=MockEstimator(), params_config={'param': [1, 2, 3]})
    model.best_params_ = {'invalid_param': 2}
    X = np.array([[1, 2], [3, 4], [5, 6]])
    y = np.array([1, 2, 3])
    with pytest.raises(ValueError):
        model._refit(X, y)

def test_refit_missing_params():
    model = HyperactiveSearchCV(estimator=MockEstimator(), params_config={'param': [1, 2, 3]})
    model.best_params_ = None
    X = np.array([[1, 2], [3, 4], [5, 6]])
    y = np.array([1, 2, 3])
    with pytest.raises(TypeError):
        model._refit(X, y)

# Additional Fit Parameters
def test_refit_with_additional_fit_params():
    model = HyperactiveSearchCV(estimator=MockEstimator(), params_config={'param': [1, 2, 3]})
    model.best_params_ = {'param': 2}
    X = np.array([[1, 2], [3, 4], [5, 6]])
    y = np.array([1, 2, 3])
    model._refit(X, y, sample_weight=[1, 1, 1])

# Large Scale Test Cases
def test_refit_large_scale():
    model = HyperactiveSearchCV(estimator=MockEstimator(), params_config={'param': [1, 2, 3]})
    model.best_params_ = {'param': 2}
    X = np.random.rand(1000, 10)
    y = np.random.randint(0, 2, 1000)
    model._refit(X, y)
# codeflash_output is used to check that the output of the original code is the same as that of the optimized code.
```

</details>


To edit these changes `git checkout codeflash/optimize-HyperactiveSearchCV._refit-m8ey8ag3` and push.

[![Codeflash](https://img.shields.io/badge/Optimized%20with-Codeflash-yellow?style=flat&color=%23ffc428&logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNDgwIiBoZWlnaHQ9ImF1dG8iIHZpZXdCb3g9IjAgMCA0ODAgMjgwIiBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTI4Ni43IDAuMzc4NDE4SDIwMS43NTFMNTAuOTAxIDE0OC45MTFIMTM1Ljg1MUwwLjk2MDkzOCAyODEuOTk5SDk1LjQzNTJMMjgyLjMyNCA4OS45NjE2SDE5Ni4zNDVMMjg2LjcgMC4zNzg0MThaIiBmaWxsPSIjRkZDMDQzIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMzExLjYwNyAwLjM3ODkwNkwyNTguNTc4IDU0Ljk1MjZIMzc5LjU2N0w0MzIuMzM5IDAuMzc4OTA2SDMxMS42MDdaIiBmaWxsPSIjMEIwQTBBIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMzA5LjU0NyA4OS45NjAxTDI1Ni41MTggMTQ0LjI3NkgzNzcuNTA2TDQzMC4wMjEgODkuNzAyNkgzMDkuNTQ3Vjg5Ljk2MDFaIiBmaWxsPSIjMEIwQTBBIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjQyLjg3MyAxNjQuNjZMMTg5Ljg0NCAyMTkuMjM0SDMxMC44MzNMMzYzLjM0NyAxNjQuNjZIMjQyLjg3M1oiIGZpbGw9IiMwQjBBMEEiLz4KPC9zdmc+Cg==)](https://codeflash.ai)