### PR TITLE
⚡️ Speed up function `joblib_wrapper` by 5%

### DIFF
--- a/src/hyperactive/distribution.py
+++ b/src/hyperactive/distribution.py
@@ -20,14 +20,18 @@ def single_process(process_func, process_infos):
 def multiprocessing_wrapper(process_func, process_infos, n_processes):
     import multiprocessing as mp
 
-    with mp.Pool(n_processes, initializer=initializer, initargs=initargs) as pool:
+    with mp.Pool(
+        n_processes, initializer=initializer, initargs=initargs
+    ) as pool:
         return pool.map(process_func, process_infos)
 
 
 def pathos_wrapper(process_func, search_processes_paras, n_processes):
     import pathos.multiprocessing as pmp
 
-    with pmp.Pool(n_processes, initializer=initializer, initargs=initargs) as pool:
+    with pmp.Pool(
+        n_processes, initializer=initializer, initargs=initargs
+    ) as pool:
         return pool.map(process_func, search_processes_paras)
 
 

--- a/src/hyperactive/distribution.py
+++ b/src/hyperactive/distribution.py
@@ -20,26 +20,20 @@ def single_process(process_func, process_infos):
 def multiprocessing_wrapper(process_func, process_infos, n_processes):
     import multiprocessing as mp
 
-    with mp.Pool(
-        n_processes, initializer=initializer, initargs=initargs
-    ) as pool:
+    with mp.Pool(n_processes, initializer=initializer, initargs=initargs) as pool:
         return pool.map(process_func, process_infos)
 
 
 def pathos_wrapper(process_func, search_processes_paras, n_processes):
     import pathos.multiprocessing as pmp
 
-    with pmp.Pool(
-        n_processes, initializer=initializer, initargs=initargs
-    ) as pool:
+    with pmp.Pool(n_processes, initializer=initializer, initargs=initargs) as pool:
         return pool.map(process_func, search_processes_paras)
 
 
 def joblib_wrapper(process_func, search_processes_paras, n_processes):
     from joblib import Parallel, delayed
 
-    jobs = [
-        delayed(process_func)(*info_dict)
-        for info_dict in search_processes_paras
-    ]
-    return Parallel(n_jobs=n_processes)(jobs)
+    return Parallel(n_jobs=n_processes)(
+        delayed(process_func)(*info_dict) for info_dict in search_processes_paras
+    )


### PR DESCRIPTION
### 📄 5% (0.05x) speedup for ***`joblib_wrapper` in `src/hyperactive/distribution.py`***

⏱️ Runtime :   **`4.43 seconds`**  **→** **`4.21 seconds`** (best of `5` runs)
<details>
<summary> 📝 Explanation and details</summary>

To optimize the given `joblib_wrapper` function, we can make a few modifications to how jobs list is created to potentially improve performance. Specifically, we can avoid using a list comprehension for creating `jobs` when passing to `Parallel`. Instead, we can utilize a generator expression directly within `Parallel` to be somewhat more memory efficient.



### Explanation of Changes.
1. Directly use a generator expression within the call to `Parallel`. This can help in reducing memory overhead as the list of jobs does not need to be fully generated in advance before it is consumed by `Parallel`.

This approach ensures that we make the code more memory efficient, potentially leading to faster execution especially when dealing with large datasets or numerous processes. The functionality of the code and its return values remain entirely unchanged.

</details>

✅ **Correctness verification report:**

| Test                        | Status            |
| --------------------------- | ----------------- |
| ⚙️ Existing Unit Tests | 🔘 **None Found** |
| 🌀 Generated Regression Tests | ✅ **12 Passed** |
| ⏪ Replay Tests | 🔘 **None Found** |
| 🔎 Concolic Coverage Tests | 🔘 **None Found** |
|📊 Tests Coverage       | 100.0% |
<details>
<summary>🌀 Generated Regression Tests Details</summary>

```python
import pytest  # used for our unit tests
from hyperactive.distribution import joblib_wrapper
from joblib import Parallel, delayed

# unit tests

# Basic Functionality



def test_empty_search_processes_paras():
    process_func = lambda x: x + 1
    search_processes_paras = []
    n_processes = 1
    codeflash_output = joblib_wrapper(process_func, search_processes_paras, n_processes)

def test_zero_processes():
    process_func = lambda x: x + 1
    search_processes_paras = [{'x': 1}]
    n_processes = 0
    with pytest.raises(ValueError):
        joblib_wrapper(process_func, search_processes_paras, n_processes)


def test_non_callable_process_func():
    process_func = "not a function"
    search_processes_paras = [{'x': 1}]
    n_processes = 1
    with pytest.raises(TypeError):
        joblib_wrapper(process_func, search_processes_paras, n_processes)

def test_invalid_dictionary_format():
    process_func = lambda x: x + 1
    search_processes_paras = [{'y': 1}]
    n_processes = 1
    with pytest.raises(TypeError):
        joblib_wrapper(process_func, search_processes_paras, n_processes)

# Performance and Scalability






def test_high_cpu_usage():
    process_func = lambda x: sum(i*i for i in range(1000))  # CPU-intensive task
    search_processes_paras = [{'x': i} for i in range(10)]
    n_processes = 4
    codeflash_output = joblib_wrapper(process_func, search_processes_paras, n_processes); results = codeflash_output

# Deterministic Output



def test_invalid_input_types():
    process_func = lambda x: x + 1
    search_processes_paras = [1, 2, 3]  # Not dictionaries
    n_processes = 2
    with pytest.raises(TypeError):
        joblib_wrapper(process_func, search_processes_paras, n_processes)
# codeflash_output is used to check that the output of the original code is the same as that of the optimized code.

import pytest  # used for our unit tests
from hyperactive.distribution import joblib_wrapper
from joblib import Parallel, delayed

# unit tests

# Basic Functionality

def test_addition_single_process():
    def add(x, y):
        return x + y
    params = [{'x': 1, 'y': 2}, {'x': 3, 'y': 4}]
    codeflash_output = joblib_wrapper(add, params, 1); result = codeflash_output

def test_string_concatenation_multiple_processes():
    def concat(a, b):
        return a + b
    params = [{'a': 'foo', 'b': 'bar'}, {'a': 'hello', 'b': 'world'}]
    codeflash_output = joblib_wrapper(concat, params, 2); result = codeflash_output

# Edge Cases

def test_empty_input():
    def dummy_func():
        return True
    params = []
    codeflash_output = joblib_wrapper(dummy_func, params, 1); result = codeflash_output



def test_invalid_function():
    params = [{'x': 1, 'y': 2}]
    with pytest.raises(TypeError, match="'int' object is not callable"):
        joblib_wrapper(123, params, 1)
# codeflash_output is used to check that the output of the original code is the same as that of the optimized code.
```

</details>


To edit these changes `git checkout codeflash/optimize-joblib_wrapper-m8ey28nh` and push.

[![Codeflash](https://img.shields.io/badge/Optimized%20with-Codeflash-yellow?style=flat&color=%23ffc428&logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNDgwIiBoZWlnaHQ9ImF1dG8iIHZpZXdCb3g9IjAgMCA0ODAgMjgwIiBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTI4Ni43IDAuMzc4NDE4SDIwMS43NTFMNTAuOTAxIDE0OC45MTFIMTM1Ljg1MUwwLjk2MDkzOCAyODEuOTk5SDk1LjQzNTJMMjgyLjMyNCA4OS45NjE2SDE5Ni4zNDVMMjg2LjcgMC4zNzg0MThaIiBmaWxsPSIjRkZDMDQzIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMzExLjYwNyAwLjM3ODkwNkwyNTguNTc4IDU0Ljk1MjZIMzc5LjU2N0w0MzIuMzM5IDAuMzc4OTA2SDMxMS42MDdaIiBmaWxsPSIjMEIwQTBBIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMzA5LjU0NyA4OS45NjAxTDI1Ni41MTggMTQ0LjI3NkgzNzcuNTA2TDQzMC4wMjEgODkuNzAyNkgzMDkuNTQ3Vjg5Ljk2MDFaIiBmaWxsPSIjMEIwQTBBIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjQyLjg3MyAxNjQuNjZMMTg5Ljg0NCAyMTkuMjM0SDMxMC44MzNMMzYzLjM0NyAxNjQuNjZIMjQyLjg3M1oiIGZpbGw9IiMwQjBBMEEiLz4KPC9zdmc+Cg==)](https://codeflash.ai)