### PR TITLE
[MNT] max concurrency for CI jobs

### DIFF
--- a/.github/workflows/tests_macos.yml
+++ b/.github/workflows/tests_macos.yml
@@ -10,6 +10,10 @@ on:
       - master
       - dev
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/tests_ubuntu.yml
+++ b/.github/workflows/tests_ubuntu.yml
@@ -10,6 +10,10 @@ on:
       - master
       - dev
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/tests_windows.yml
+++ b/.github/workflows/tests_windows.yml
@@ -10,6 +10,10 @@ on:
       - master
       - dev
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
This PR ensures that only a single set of jobs from a pull request can run - if a new batch is triggered by a push, all old batches are cancelled.

Up until now, that did not happen, and they had to be cancelled manually - potentially eating up runners.