### PR TITLE
[MNT] skip `multiprocessing` tests that hang on windows

### DIFF
--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -1,5 +1,7 @@
 import numpy as np
+import pytest
 from tqdm import tqdm
+
 from hyperactive import Hyperactive
 
 
@@ -71,12 +73,14 @@ def test_n_jobs_7():
     hyper.run()
 
 
+@pytest.mark.skip(reason="This test is not working on Windows")
 def test_multiprocessing_0():
     hyper = Hyperactive(distribution="multiprocessing")
     hyper.add_search(objective_function, search_space, n_iter=15, n_jobs=2)
     hyper.run()
 
 
+@pytest.mark.skip(reason="This test is not working on Windows")
 def test_multiprocessing_1():
     hyper = Hyperactive(
         distribution={

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -119,6 +119,7 @@ def test_joblib_1():
     hyper.run()
 
 
+@pytest.mark.skip(reason="This test is not working on Windows")
 def test_pathos_0():
     hyper = Hyperactive(distribution="pathos")
     hyper.add_search(objective_function, search_space, n_iter=15, n_jobs=2)


### PR DESCRIPTION
skips the `multiprocessing` tests that hang on windows - attempts to fix https://github.com/SimonBlanke/Hyperactive/issues/83