### PR TITLE
[MNT] remove `tqdm` progress bars and dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ classifiers=[
 
 dependencies = [
   "numpy >=1.18.1, <3.0.0",
-  "tqdm >=4.48.0, <5.0.0",
   "pandas <3.0.0",
   "gradient-free-optimizers >=1.2.4, <2.0.0",
 ]

--- a/src/hyperactive/distribution.py
+++ b/src/hyperactive/distribution.py
@@ -3,14 +3,9 @@
 # License: MIT License
 
 from sys import platform
-from tqdm import tqdm
 
-if platform.startswith("linux"):
-    initializer = tqdm.set_lock
-    initargs = (tqdm.get_lock(),)
-else:
-    initializer = None
-    initargs = ()
+initializer = None
+initargs = ()
 
 
 def single_process(process_func, process_infos):

--- a/src/hyperactive/process.py
+++ b/src/hyperactive/process.py
@@ -3,19 +3,9 @@
 # License: MIT License
 
 
-from tqdm import tqdm
-
-
 def _process_(nth_process, optimizer):
-    if "progress_bar" in optimizer.verbosity:
-        p_bar = tqdm(
-            position=nth_process,
-            total=optimizer.n_iter,
-            ascii=" ─",
-            colour="Yellow",
-        )
-    else:
-        p_bar = None
+
+    p_bar = None
 
     optimizer.search(nth_process, p_bar)
 

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -1,5 +1,4 @@
 import numpy as np
-from tqdm import tqdm
 from hyperactive import Hyperactive
 
 
@@ -73,19 +72,6 @@ def test_n_jobs_7():
 
 def test_multiprocessing_0():
     hyper = Hyperactive(distribution="multiprocessing")
-    hyper.add_search(objective_function, search_space, n_iter=15, n_jobs=2)
-    hyper.run()
-
-
-def test_multiprocessing_1():
-    hyper = Hyperactive(
-        distribution={
-            "multiprocessing": {
-                "initializer": tqdm.set_lock,
-                "initargs": (tqdm.get_lock(),),
-            }
-        },
-    )
     hyper.add_search(objective_function, search_space, n_iter=15, n_jobs=2)
     hyper.run()
 

--- a/tests/test_optimizers/test_gfo_wrapper.py
+++ b/tests/test_optimizers/test_gfo_wrapper.py
@@ -1,7 +1,6 @@
 import pytest
 import numpy as np
 
-from tqdm import tqdm
 from ._parametrize import optimizers
 from hyperactive.search_space import SearchSpace
 
@@ -99,6 +98,6 @@ def test_gfo_opt_wrapper_0(Optimizer, search_space, objective):
         verbosity=verbosity,
     )
     opt.max_time = None
-    opt.search(nth_process=0, p_bar=tqdm(total=n_iter))
+    opt.search(nth_process=0)
 
     assert opt.best_score == objective_function(opt.best_para)


### PR DESCRIPTION
This PR removes `tqdm` and all related (progress bar) functionality.

This is diagnostic, on suspicion that `tqdm` interacts with multiprocessing and causes the failures in https://github.com/SimonBlanke/Hyperactive/issues/83