### PR TITLE
[DOC] add `r` prefix in docstirngs with TeX backslashes

### DIFF
--- a/src/hyperactive/experiment/toy/_parabola.py
+++ b/src/hyperactive/experiment/toy/_parabola.py
@@ -5,7 +5,7 @@ from hyperactive.base import BaseExperiment
 
 
 class Parabola(BaseExperiment):
-    """2D parabola, common benchmark for optimization algorithms.
+    r"""2D parabola, common benchmark for optimization algorithms.
 
     Parabola parameterized by the formula:
 

--- a/src/hyperactive/experiment/toy/_sphere.py
+++ b/src/hyperactive/experiment/toy/_sphere.py
@@ -7,7 +7,7 @@ from hyperactive.base import BaseExperiment
 
 
 class Sphere(BaseExperiment):
-    """Simple Sphere function, common benchmark for optimization algorithms.
+    r"""Simple Sphere function, common benchmark for optimization algorithms.
 
     Sphere function parameterized by the formula:
 


### PR DESCRIPTION
TeX formulae with single backslashes are not properly rendered in rst unless the `r` prefix is present. This is added to two docstrings lacking these.