### PR TITLE
[MNT] bound `scikit-learn < 1.7.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,11 +42,12 @@ dependencies = [
   "pandas <3.0.0",
   "gradient-free-optimizers >=1.2.4, <2.0.0",
   "scikit-base <1.0.0",
+  "scikit-learn <1.7.0",
 ]
 
 [project.optional-dependencies]
 sklearn-integration = [
-  "scikit-learn == 1.6.1",
+  "scikit-learn <1.7.0",
 ]
 build = [
   "setuptools",


### PR DESCRIPTION
Temporarily bounds `sklearn < 1.7.0` until the issues with compatibility are resolved.

A bound also has to be added in the core dependencies, since `scikit-learn` is a core dependency (there are direct imports), but this was not managed, only indirectly through `gradient-free-optimizers`.

See https://github.com/SimonBlanke/Hyperactive/issues/128