### PR TITLE
[MNT] isolate `tqdm` as soft dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ classifiers=[
 
 dependencies = [
   "numpy >=1.18.1, <3.0.0",
-  "tqdm >=4.48.0, <5.0.0",
   "pandas <3.0.0",
   "gradient-free-optimizers >=1.2.4, <2.0.0",
   "scikit-base <1.0.0",
@@ -46,7 +45,7 @@ dependencies = [
 
 [project.optional-dependencies]
 sklearn-integration = [
-  "scikit-learn == 1.6.1",
+  "scikit-learn<1.7.0",
 ]
 build = [
   "setuptools",
@@ -60,9 +59,8 @@ test = [
   "pathos",
 ]
 all_extras = [
-  "hyperactive[build]",
-  "hyperactive[test]",
   "hyperactive[integrations]",
+  "tqdm >=4.48.0, <5.0.0",
 ]
 
 

--- a/src/hyperactive/distribution.py
+++ b/src/hyperactive/distribution.py
@@ -2,10 +2,13 @@
 # Email: simon.blanke@yahoo.com
 # License: MIT License
 
+from skbase.utils.dependencies import _check_soft_dependencies
 from sys import platform
-from tqdm import tqdm
 
-if platform.startswith("linux"):
+if platform.startswith("linux") and _check_soft_dependencies("tqdm", severity="none"):
+    from tqdm import tqdm
+
+    # Use tqdm's lock for multiprocessing to avoid issues with progress bars
     initializer = tqdm.set_lock
     initargs = (tqdm.get_lock(),)
 else:

--- a/src/hyperactive/process.py
+++ b/src/hyperactive/process.py
@@ -3,11 +3,14 @@
 # License: MIT License
 
 
-from tqdm import tqdm
-
-
 def _process_(nth_process, optimizer):
     if "progress_bar" in optimizer.verbosity:
+        from skbase.utils.dependencies import _check_soft_dependencies
+
+        _check_soft_dependencies("tqdm", obj="progress_bar verbosity")
+
+        from tqdm import tqdm
+
         p_bar = tqdm(
             position=nth_process,
             total=optimizer.n_iter,

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -1,6 +1,6 @@
 import numpy as np
 import sys, pytest
-from tqdm import tqdm
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from hyperactive import Hyperactive
 
@@ -82,7 +82,10 @@ def test_multiprocessing_0():
     hyper.run()
 
 
+@pytest.mark.skipif(not _check_soft_dependencies("tqdm"), severity="none")
 def test_multiprocessing_1():
+    from tqdm import tqdm
+
     hyper = Hyperactive(
         distribution={
             "multiprocessing": {

--- a/tests/test_optimizers/test_gfo_wrapper.py
+++ b/tests/test_optimizers/test_gfo_wrapper.py
@@ -1,7 +1,7 @@
 import pytest
 import numpy as np
+from skbase.utils.dependencies import _check_soft_dependencies
 
-from tqdm import tqdm
 from ._parametrize import optimizers
 from hyperactive.search_space import SearchSpace
 
@@ -99,6 +99,14 @@ def test_gfo_opt_wrapper_0(Optimizer, search_space, objective):
         verbosity=verbosity,
     )
     opt.max_time = None
-    opt.search(nth_process=0, p_bar=tqdm(total=n_iter))
+
+    if _check_soft_dependencies("tqdm", severity="none"):
+        from tqdm import tqdm
+
+        p_bar_kwargs = {"p_bar": tqdm(total=n_iter)}
+    else:
+        p_bar_kwargs = {}
+
+    opt.search(nth_process=0, **p_bar_kwargs)
 
     assert opt.best_score == objective_function(opt.best_para)


### PR DESCRIPTION
This PR turns `tqdm` into a soft dependency of `hyperactive` proper.

Alternative of https://github.com/SimonBlanke/Hyperactive/pull/117