### PR TITLE
[ENH] sign handling in experiments and optimization

### DIFF
--- a/extension_templates/experiments.py
+++ b/extension_templates/experiments.py
@@ -234,10 +234,11 @@ class MyExperiment(BaseExperiment):
 
     @classmethod
     def _get_score_params(self):
-        """Return settings for testing the score function. Used in tests only.
+        """Return settings for testing score/evaluate functions. Used in tests only.
 
-        Returns a list, the i-th element corresponds to self.get_test_params()[i].
-        It should be a valid call for self.evaluate.
+        Returns a list, the i-th element should be valid arguments for
+        self.evaluate and self.score, of an instance constructed with
+        self.get_test_params()[i].
 
         Returns
         -------

--- a/extension_templates/experiments.py
+++ b/extension_templates/experiments.py
@@ -75,11 +75,11 @@ class MyExperiment(BaseExperiment):
         #
         "property:randomness": "random",
         # valid values: "random", "deterministic"
-        # if "deterministic", two calls of score must result in the same value
+        # if "deterministic", two calls of "evaluate" must result in the same value
         #
         "property:higher_or_lower_is_better": "lower",
         # valid values: "higher", "lower", "mixed"
-        # whether higher or lower scores are better
+        # whether higher or lower returns of "evaluate" are better
         #
         # --------------
         # packaging info
@@ -151,25 +151,25 @@ class MyExperiment(BaseExperiment):
         return ["score_param1", "score_param2"]
 
     # todo: implement this, mandatory
-    def _score(self, params):
-        """Score the parameters.
+    def _evaluate(self, params):
+        """Evaluate the parameters.
 
         Parameters
         ----------
         params : dict with string keys
-            Parameters to score.
+            Parameters to evaluate.
 
         Returns
         -------
         float
-            The score of the parameters.
+            The value of the parameters as per evaluation.
         dict
             Additional metadata about the search.
         """
         # params is a dictionary with keys being paramnames or subset thereof
         # IMPORTANT: avoid side effects to params!
         #
-        # the method may work if only a subste of the parameters in paramnames is passed
+        # the method may work if only a subset of the parameters in paramnames is passed
         # but this is not necessary
         value = 42  # must be numpy.float64
         metadata = {"some": "metadata"}  # can be any dict

--- a/extension_templates/experiments.py
+++ b/extension_templates/experiments.py
@@ -237,7 +237,7 @@ class MyExperiment(BaseExperiment):
         """Return settings for testing the score function. Used in tests only.
 
         Returns a list, the i-th element corresponds to self.get_test_params()[i].
-        It should be a valid call for self.score.
+        It should be a valid call for self.evaluate.
 
         Returns
         -------

--- a/extension_templates/experiments.py
+++ b/extension_templates/experiments.py
@@ -245,7 +245,7 @@ class MyExperiment(BaseExperiment):
             The parameters to be used for scoring.
         """
         # dict keys should be same as paramnames return
-        # or subset, only if _score allows for subsets of parameters
+        # or subset, only if _evaluate allows for subsets of parameters
         score_params1 = {"score_param1": "foo", "score_param2": "bar"}
         score_params2 = {"score_param1": "baz", "score_param2": "qux"}
         return [score_params1, score_params2]

--- a/extension_templates/experiments.py
+++ b/extension_templates/experiments.py
@@ -77,6 +77,10 @@ class MyExperiment(BaseExperiment):
         # valid values: "random", "deterministic"
         # if "deterministic", two calls of score must result in the same value
         #
+        "property:higher_or_lower_is_better": "lower",
+        # valid values: "higher", "lower", "mixed"
+        # whether higher or lower scores are better
+        #
         # --------------
         # packaging info
         # --------------

--- a/extension_templates/optimizers.py
+++ b/extension_templates/optimizers.py
@@ -142,7 +142,8 @@ class MyOptimizer(BaseOptimizer):
         return ["score_param1", "score_param2"]
 
     # optional: implement this to prepare arguments for _run
-    # the default is all parameters passed to __init__, except ex
+    # the default is all parameters passed to __init__, minus the experiment
+    # the result of this is passed to _run as search_config
     def get_search_config(self):
         """Get the search configuration.
 
@@ -153,12 +154,15 @@ class MyOptimizer(BaseOptimizer):
         """
         # the default
         search_config = super().get_search_config()
+        # example of adding a new parameter to the search config
+        # this is optional, but can be useful for clean separation or API interfacing
         search_config["one_more_param"] = 42
+        # this return is available in _run as search_config
         return search_config
 
     # todo: implement this, mandatory
     def _run(self, experiment, **search_config):
-        """Run the optimization search process.
+        """Run the optimization search process to maximize the experiment's score.
 
         Parameters
         ----------
@@ -173,6 +177,8 @@ class MyOptimizer(BaseOptimizer):
             The best parameters found during the search.
             Must have keys a subset or identical to experiment.paramnames().
         """
+        # important: the search logic should *maximize* the experiment's score
+        # this is the main method to implement, it should return the best parameters
         best_params = {"write_some_logic_to_get": "best_params"}
         return best_params
 

--- a/src/hyperactive/base/_experiment.py
+++ b/src/hyperactive/base/_experiment.py
@@ -114,9 +114,9 @@ class BaseExperiment(BaseObject):
         """
         hib = self.get_tag("property:higher_or_lower_is_better", "lower")
         if hib == "higher":
-            sign = -1
-        elif hib == "lower":
             sign = 1
+        elif hib == "lower":
+            sign = -1
 
         score_res = self.evaluate(params)
 

--- a/src/hyperactive/base/_experiment.py
+++ b/src/hyperactive/base/_experiment.py
@@ -14,7 +14,7 @@ class BaseExperiment(BaseObject):
         "property:randomness": "random",  # random or deterministic
         # if deterministic, two calls of score will result in the same value
         # random = two calls may result in different values; same as "stochastic"
-        "property:higher_or_lower_is_better": "lower",  # "higher", "lower", "mixed"
+        "property:higher_or_lower_is_better": "higher",  # "higher", "lower", "mixed"
         # whether higher or lower scores are better
     }
 
@@ -22,8 +22,8 @@ class BaseExperiment(BaseObject):
         super().__init__()
 
     def __call__(self, **kwargs):
-        """Score parameters, with kwargs call. Same as cost call."""
-        score, _ = self.cost(kwargs)
+        """Score parameters, with kwargs call. Same as score call."""
+        score, _ = self.score(kwargs)
         return score
 
     @property
@@ -50,55 +50,55 @@ class BaseExperiment(BaseObject):
         """
         raise NotImplementedError
 
-    def score(self, params):
-        """Score the parameters.
+    def evaluate(self, params):
+        """Evaluate the parameters.
 
         Parameters
         ----------
         params : dict with string keys
-            Parameters to score.
+            Parameters to evaluate.
 
         Returns
         -------
         float
-            The score of the parameters.
+            The value of the parameters as per evaluation.
         dict
             Additional metadata about the search.
         """
         paramnames = self.paramnames()
         if not set(params.keys()) <= set(paramnames):
             raise ValueError("Parameters do not match.")
-        res, metadata = self._score(params)
+        res, metadata = self._evaluate(params)
         res = np.float64(res)
         return res, metadata
 
-    def _score(self, params):
-        """Score the parameters.
+    def _evaluate(self, params):
+        """Evaluate the parameters.
 
         Parameters
         ----------
         params : dict with string keys
-            Parameters to score.
+            Parameters to evaluate.
 
         Returns
         -------
         float
-            The score of the parameters.
+            The value of the parameters as per evaluation.
         dict
             Additional metadata about the search.
         """
         raise NotImplementedError
 
-    def cost(self, params):
-        """Score the parameters - with sign such that lower is better.
+    def score(self, params):
+        """Score the parameters - with sign such that higher is always better.
 
-        Same as ``score`` call except for the sign.
+        Same as ``evaluate`` call except for the sign chosen so that higher is better.
 
         If the tag ``property:higher_or_lower_is_better`` is set to
-        ``"higher"``, the result is ``-self.score(params)``.
+        ``"lower"``, the result is ``-self.evaluate(params)``.
 
-        If the tag is set to ``"lower"``, the result is
-        identical to ``self.score(params)``.
+        If the tag is set to ``"higher"``, the result is
+        identical to ``self.evaluate(params)``.
 
         Parameters
         ----------
@@ -118,6 +118,6 @@ class BaseExperiment(BaseObject):
         elif hib == "lower":
             sign = 1
 
-        score_res = self.score(params)
+        score_res = self.evaluate(params)
 
         return sign * score_res[0], score_res[1]

--- a/src/hyperactive/base/_experiment.py
+++ b/src/hyperactive/base/_experiment.py
@@ -118,6 +118,8 @@ class BaseExperiment(BaseObject):
         elif hib == "lower":
             sign = -1
 
-        score_res = self.evaluate(params)
+        eval_res = self.evaluate(params)
+        value = eval_res[0]
+        metadata = eval_res[1]
 
-        return sign * score_res[0], score_res[1]
+        return sign * value, metadata

--- a/src/hyperactive/base/_optimizer.py
+++ b/src/hyperactive/base/_optimizer.py
@@ -52,9 +52,9 @@ class BaseOptimizer(BaseObject):
         return self._experiment
 
     def run(self):
-        """Run the optimization search process.
+        """Run the optimization search process to maximize the experiment's score.
 
-        The optimization searches for the maximizer of the experiment's
+        The optimization searches for a maximizer of the experiment's
         ``score`` method.
 
         Depending on the tag ``property:higher_or_lower_is_better`` being

--- a/src/hyperactive/base/_optimizer.py
+++ b/src/hyperactive/base/_optimizer.py
@@ -54,10 +54,21 @@ class BaseOptimizer(BaseObject):
     def run(self):
         """Run the optimization search process.
 
+        The optimization searches for the maximizer of the experiment's
+        ``score`` method.
+
+        Depending on the tag ``property:higher_or_lower_is_better`` being
+        set to ``higher`` or ``lower``, the ``run`` method will search for:
+
+        * the minimizer of the ``evaluate`` method if the tag is ``lower``
+        * the maximizer of the ``evaluate`` method if the tag is ``higher``
+
         Returns
         -------
         best_params : dict
             The best parameters found during the optimization process.
+            The dict ``best_params`` can be used in ``experiment.score`` or
+            ``experiment.evaluate`` directly.
         """
         experiment = self.get_experiment()
         search_config = self.get_search_config()

--- a/src/hyperactive/experiment/integrations/sklearn_cv.py
+++ b/src/hyperactive/experiment/integrations/sklearn_cv.py
@@ -228,10 +228,11 @@ class SklearnCvExperiment(BaseExperiment):
 
     @classmethod
     def _get_score_params(self):
-        """Return settings for testing the score function. Used in tests only.
+        """Return settings for testing score/evaluate functions. Used in tests only.
 
-        Returns a list, the i-th element corresponds to self.get_test_params()[i].
-        It should be a valid call for self.score.
+        Returns a list, the i-th element should be valid arguments for
+        self.evaluate and self.score, of an instance constructed with
+        self.get_test_params()[i].
 
         Returns
         -------

--- a/src/hyperactive/experiment/integrations/sklearn_cv.py
+++ b/src/hyperactive/experiment/integrations/sklearn_cv.py
@@ -127,18 +127,18 @@ class SklearnCvExperiment(BaseExperiment):
         """
         return list(self.estimator.get_params().keys())
 
-    def _score(self, params):
-        """Score the parameters.
+    def _evaluate(self, params):
+        """Evaluate the parameters.
 
         Parameters
         ----------
         params : dict with string keys
-            Parameters to score.
+            Parameters to evaluate.
 
         Returns
         -------
         float
-            The score of the parameters.
+            The value of the parameters as per evaluation.
         dict
             Additional metadata about the search.
         """

--- a/src/hyperactive/experiment/integrations/sklearn_cv.py
+++ b/src/hyperactive/experiment/integrations/sklearn_cv.py
@@ -110,6 +110,13 @@ class SklearnCvExperiment(BaseExperiment):
                 self._scoring = make_scorer(scoring)
         self.scorer_ = self._scoring
 
+        # Set the sign of the scoring function
+        if hasattr(self._scoring, "_score"):
+            score_func = self._scoring._score_func
+            _sign = _guess_sign_of_sklmetric(score_func)
+            _sign_str = "higher" if _sign == 1 else "lower"
+            self.set_tags(**{"property:higher_or_lower_is_better": _sign_str})
+
     def _paramnames(self):
         """Return the parameter names of the search.
 
@@ -235,3 +242,80 @@ class SklearnCvExperiment(BaseExperiment):
         score_params_regress = {"C": 1.0, "kernel": "linear"}
         score_params_defaults = {"C": 1.0, "kernel": "linear"}
         return [score_params_classif, score_params_regress, score_params_defaults]
+
+
+def _guess_sign_of_sklmetric(scorer):
+    """Guess the sign of a sklearn metric scorer.
+
+    Parameters
+    ----------
+    scorer : callable
+        The sklearn metric scorer to guess the sign for.
+
+    Returns
+    -------
+    int
+        1 if higher scores are better, -1 if lower scores are better.
+    """
+    HIGHER_IS_BETTER = {
+        # Classification
+        "accuracy_score": True,
+        "auc": True,
+        "average_precision_score": True,
+        "balanced_accuracy_score": True,
+        "brier_score_loss": False,
+        "class_likelihood_ratios": False,
+        "cohen_kappa_score": True,
+        "d2_log_loss_score": True,
+        "dcg_score": True,
+        "f1_score": True,
+        "fbeta_score": True,
+        "hamming_loss": False,
+        "hinge_loss": False,
+        "jaccard_score": True,
+        "log_loss": False,
+        "matthews_corrcoef": True,
+        "ndcg_score": True,
+        "precision_score": True,
+        "recall_score": True,
+        "roc_auc_score": True,
+        "top_k_accuracy_score": True,
+        "zero_one_loss": False,
+
+        # Regression
+        "d2_absolute_error_score": True,
+        "d2_pinball_score": True,
+        "d2_tweedie_score": True,
+        "explained_variance_score": True,
+        "max_error": False,
+        "mean_absolute_error": False,
+        "mean_absolute_percentage_error": False,
+        "mean_gamma_deviance": False,
+        "mean_pinball_loss": False,
+        "mean_poisson_deviance": False,
+        "mean_squared_error": False,
+        "mean_squared_log_error": False,
+        "mean_tweedie_deviance": False,
+        "median_absolute_error": False,
+        "r2_score": True,
+        "root_mean_squared_error": False,
+        "root_mean_squared_log_error": False,
+    }
+
+    scorer_name = getattr(scorer, "__name__", None)
+
+    if hasattr(scorer, "greater_is_better"):
+        return 1 if scorer.greater_is_better else -1
+    elif scorer_name in HIGHER_IS_BETTER:
+        return 1 if HIGHER_IS_BETTER[scorer_name] else -1
+    elif scorer_name.endswith("_score"):
+        # If the scorer name ends with "_score", we assume higher is better
+        return 1
+    elif scorer_name.endswith("_loss") or scorer_name.endswith("_deviance"):
+        # If the scorer name ends with "_loss", we assume lower is better
+        return -1
+    elif scorer_name.endswith("_error"):
+        return -1
+    else:
+        # If we cannot determine the sign, we assume lower is better
+        return -1

--- a/src/hyperactive/experiment/toy/_ackley.py
+++ b/src/hyperactive/experiment/toy/_ackley.py
@@ -49,6 +49,9 @@ class Ackley(BaseExperiment):
         "property:randomness": "deterministic",  # random or deterministic
         # if deterministic, two calls of score will result in the same value
         # random = two calls may result in different values; same as "stochastic"
+        "property:higher_or_lower_is_better": "lower",
+        # values are "higher", "lower", "mixed"
+        # whether higher or lower scores are better
     }
 
     def __init__(self, a=20, b=0.2, c=2 * np.pi, d=2):
@@ -61,7 +64,21 @@ class Ackley(BaseExperiment):
     def _paramnames(self):
         return [f"x{i}" for i in range(self.d)]
 
-    def _score(self, params):
+    def _evaluate(self, params):
+        """Evaluate the parameters.
+
+        Parameters
+        ----------
+        params : dict with string keys
+            Parameters to evaluate.
+
+        Returns
+        -------
+        float
+            The value of the parameters as per evaluation.
+        dict
+            Additional metadata about the search.
+        """
         x_vec = np.array([params[f"x{i}"] for i in range(self.d)])
 
         loss1 = -self.a * np.exp(-self.b * np.sqrt(np.sum(x_vec**2) / self.d))

--- a/src/hyperactive/experiment/toy/_ackley.py
+++ b/src/hyperactive/experiment/toy/_ackley.py
@@ -127,10 +127,11 @@ class Ackley(BaseExperiment):
 
     @classmethod
     def _get_score_params(self):
-        """Return settings for testing the score function. Used in tests only.
+        """Return settings for testing score/evaluate functions. Used in tests only.
 
-        Returns a list, the i-th element corresponds to self.get_test_params()[i].
-        It should be a valid call for self.score.
+        Returns a list, the i-th element should be valid arguments for
+        self.evaluate and self.score, of an instance constructed with
+        self.get_test_params()[i].
 
         Returns
         -------

--- a/src/hyperactive/experiment/toy/_parabola.py
+++ b/src/hyperactive/experiment/toy/_parabola.py
@@ -79,10 +79,11 @@ class Parabola(BaseExperiment):
 
     @classmethod
     def _get_score_params(self):
-        """Return settings for testing the score function. Used in tests only.
+        """Return settings for testing score/evaluate functions. Used in tests only.
 
-        Returns a list, the i-th element corresponds to self.get_test_params()[i].
-        It should be a valid call for self.score.
+        Returns a list, the i-th element should be valid arguments for
+        self.evaluate and self.score, of an instance constructed with
+        self.get_test_params()[i].
 
         Returns
         -------

--- a/src/hyperactive/experiment/toy/_parabola.py
+++ b/src/hyperactive/experiment/toy/_parabola.py
@@ -43,6 +43,9 @@ class Parabola(BaseExperiment):
         "property:randomness": "deterministic",  # random or deterministic
         # if deterministic, two calls of score will result in the same value
         # random = two calls may result in different values; same as "stochastic"
+        "property:higher_or_lower_is_better": "lower",
+        # values are "higher", "lower", "mixed"
+        # whether higher or lower scores are better
     }
 
     def __init__(self, a=1.0, b=0.0, c=0.0):
@@ -54,7 +57,21 @@ class Parabola(BaseExperiment):
     def _paramnames(self):
         return ["x", "y"]
 
-    def _score(self, params):
+    def _evaluate(self, params):
+        """Evaluate the parameters.
+
+        Parameters
+        ----------
+        params : dict with string keys
+            Parameters to evaluate.
+
+        Returns
+        -------
+        float
+            The value of the parameters as per evaluation.
+        dict
+            Additional metadata about the search.
+        """
         x = params["x"]
         y = params["y"]
 

--- a/src/hyperactive/experiment/toy/_sphere.py
+++ b/src/hyperactive/experiment/toy/_sphere.py
@@ -50,6 +50,9 @@ class Sphere(BaseExperiment):
         "property:randomness": "deterministic",  # random or deterministic
         # if deterministic, two calls of score will result in the same value
         # random = two calls may result in different values; same as "stochastic"
+        "property:higher_or_lower_is_better": "lower",
+        # values are "higher", "lower", "mixed"
+        # whether higher or lower scores are better
     }
 
     def __init__(self, const=0, n_dim=2):
@@ -61,7 +64,21 @@ class Sphere(BaseExperiment):
     def _paramnames(self):
         return [f"x{i}" for i in range(self.n_dim)]
 
-    def _score(self, params):
+    def _evaluate(self, params):
+        """Evaluate the parameters.
+
+        Parameters
+        ----------
+        params : dict with string keys
+            Parameters to evaluate.
+
+        Returns
+        -------
+        float
+            The value of the parameters as per evaluation.
+        dict
+            Additional metadata about the search.
+        """
         params_vec = np.array([params[f"x{i}"] for i in range(self.n_dim)])
         return np.sum(params_vec ** 2) + self.const, {}
 

--- a/src/hyperactive/experiment/toy/_sphere.py
+++ b/src/hyperactive/experiment/toy/_sphere.py
@@ -121,10 +121,11 @@ class Sphere(BaseExperiment):
 
     @classmethod
     def _get_score_params(self):
-        """Return settings for testing the score function. Used in tests only.
+        """Return settings for testing score/evaluate functions. Used in tests only.
 
-        Returns a list, the i-th element corresponds to self.get_test_params()[i].
-        It should be a valid call for self.score.
+        Returns a list, the i-th element should be valid arguments for
+        self.evaluate and self.score, of an instance constructed with
+        self.get_test_params()[i].
 
         Returns
         -------

--- a/src/hyperactive/opt/_adapters/_gfo.py
+++ b/src/hyperactive/opt/_adapters/_gfo.py
@@ -133,7 +133,7 @@ class _BaseGFOadapter(BaseOptimizer):
 
         with StdoutMute(active=not self.verbose):
             gfopt.search(
-                objective_function=experiment.score,
+                objective_function=experiment.cost,
                 n_iter=n_iter,
                 max_time=max_time,
             )

--- a/src/hyperactive/opt/_adapters/_gfo.py
+++ b/src/hyperactive/opt/_adapters/_gfo.py
@@ -133,7 +133,7 @@ class _BaseGFOadapter(BaseOptimizer):
 
         with StdoutMute(active=not self.verbose):
             gfopt.search(
-                objective_function=experiment.cost,
+                objective_function=experiment.score,
                 n_iter=n_iter,
                 max_time=max_time,
             )

--- a/src/hyperactive/tests/test_all_objects.py
+++ b/src/hyperactive/tests/test_all_objects.py
@@ -201,8 +201,8 @@ class TestAllExperiments(ExperimentFixtureGenerator, _QuickTester):
             call_sc = inst(**obj)
             assert isinstance(call_sc, float), f"Score is not a float: {call_sc}"
             if det_tag == "deterministic":
-                msg = f"Score does not match: {e_score} != {call_sc}"
-                assert e_score == call_sc, msg
+                msg = f"Score does not match: {score} != {call_sc}"
+                assert score == call_sc, msg
 
             sign_tag = inst.get_tag("property:higher_or_lower_is_better", "higher")
             if sign_tag == "higher" and det_tag == "deterministic":

--- a/src/hyperactive/tests/test_all_objects.py
+++ b/src/hyperactive/tests/test_all_objects.py
@@ -204,7 +204,7 @@ class TestAllExperiments(ExperimentFixtureGenerator, _QuickTester):
                 msg = f"Score does not match: {res} != {call_sc}"
                 assert e_score == call_sc, msg
 
-            sign_tag = inst.get_tag("property:higher_or_lower_is_better", "lower")
+            sign_tag = inst.get_tag("property:higher_or_lower_is_better", "higher")
             if sign_tag == "higher" and det_tag == "deterministic":
                 assert e_score == res
             elif sign_tag == "lower" and det_tag == "deterministic":

--- a/src/hyperactive/tests/test_all_objects.py
+++ b/src/hyperactive/tests/test_all_objects.py
@@ -45,6 +45,7 @@ class PackageConfig:
         "maintainers",
         # experiments
         "property:randomness",
+        "property:higher_or_lower_is_better",
         # optimizers
         "info:name",  # str
         "info:local_vs_global",  # "local", "mixed", "global"
@@ -184,10 +185,19 @@ class TestAllExperiments(ExperimentFixtureGenerator, _QuickTester):
             assert isinstance(score, float), f"Score is not a float: {score}"
             assert isinstance(metadata, dict), f"Metadata is not a dict: {metadata}"
 
+            cost_res = inst.cost(obj)
+            msg = f"Cost function did not return a length two tuple: {res}"
+            assert isinstance(cost_res, tuple) and len(cost_res) == 2, msg
+            c_score, c_metadata = cost_res
+            assert isinstance(c_score, float), f"Score is not a float: {c_score}"
+            assert isinstance(c_metadata, dict), f"Metadata is not a dict: {c_metadata}"
+
+            assert abs(c_score) == score
+
             call_sc = inst(**obj)
             assert isinstance(call_sc, float), f"Score is not a float: {call_sc}"
             if inst.get_tag("property:randomness") == "deterministic":
-                assert score == call_sc, f"Score does not match: {score} != {call_sc}"
+                assert c_score == call_sc, f"Score does not match: {score} != {call_sc}"
 
 
 class OptimizerFixtureGenerator(BaseFixtureGenerator):

--- a/src/hyperactive/tests/test_all_objects.py
+++ b/src/hyperactive/tests/test_all_objects.py
@@ -201,14 +201,14 @@ class TestAllExperiments(ExperimentFixtureGenerator, _QuickTester):
             call_sc = inst(**obj)
             assert isinstance(call_sc, float), f"Score is not a float: {call_sc}"
             if det_tag == "deterministic":
-                msg = f"Score does not match: {res} != {call_sc}"
+                msg = f"Score does not match: {e_score} != {call_sc}"
                 assert e_score == call_sc, msg
 
             sign_tag = inst.get_tag("property:higher_or_lower_is_better", "higher")
             if sign_tag == "higher" and det_tag == "deterministic":
-                assert e_score == res
+                assert score == e_score
             elif sign_tag == "lower" and det_tag == "deterministic":
-                assert e_score == -res
+                assert score == -e_score
 
 
 class OptimizerFixtureGenerator(BaseFixtureGenerator):

--- a/src/hyperactive/tests/test_all_objects.py
+++ b/src/hyperactive/tests/test_all_objects.py
@@ -192,15 +192,23 @@ class TestAllExperiments(ExperimentFixtureGenerator, _QuickTester):
             assert isinstance(e_score, float), f"Score is not a float: {e_score}"
             assert isinstance(e_metadata, dict), f"Metadata is not a dict: {e_metadata}"
 
-            if inst.get_tag("property:randomness") == "deterministic":
+            det_tag = inst.get_tag("property:randomness", "random")
+
+            if det_tag == "deterministic":
                 msg = f"Score and eval calls do not match: |{e_score}| != |{score}|"
                 assert abs(e_score) == abs(score), msg
 
             call_sc = inst(**obj)
             assert isinstance(call_sc, float), f"Score is not a float: {call_sc}"
-            if inst.get_tag("property:randomness") == "deterministic":
+            if det_tag == "deterministic":
                 msg = f"Score does not match: {res} != {call_sc}"
                 assert e_score == call_sc, msg
+
+            sign_tag = inst.get_tag("property:higher_or_lower_is_better", "lower")
+            if sign_tag == "higher" and det_tag == "deterministic":
+                assert e_score == res
+            elif sign_tag == "lower" and det_tag == "deterministic":
+                assert e_score == -res
 
 
 class OptimizerFixtureGenerator(BaseFixtureGenerator):

--- a/src/hyperactive/tests/test_all_objects.py
+++ b/src/hyperactive/tests/test_all_objects.py
@@ -185,22 +185,22 @@ class TestAllExperiments(ExperimentFixtureGenerator, _QuickTester):
             assert isinstance(score, float), f"Score is not a float: {score}"
             assert isinstance(metadata, dict), f"Metadata is not a dict: {metadata}"
 
-            cost_res = inst.cost(obj)
-            msg = f"Cost function did not return a length two tuple: {res}"
-            assert isinstance(cost_res, tuple) and len(cost_res) == 2, msg
-            c_score, c_metadata = cost_res
-            assert isinstance(c_score, float), f"Score is not a float: {c_score}"
-            assert isinstance(c_metadata, dict), f"Metadata is not a dict: {c_metadata}"
+            eval_res = inst.evaluate(obj)
+            msg = f"eval function did not return a length two tuple: {res}"
+            assert isinstance(eval_res, tuple) and len(eval_res) == 2, msg
+            e_score, e_metadata = eval_res
+            assert isinstance(e_score, float), f"Score is not a float: {e_score}"
+            assert isinstance(e_metadata, dict), f"Metadata is not a dict: {e_metadata}"
 
             if inst.get_tag("property:randomness") == "deterministic":
-                msg = f"Score and cost calls do not match: |{c_score}| != |{score}|"
-                assert abs(c_score) == abs(score), msg
+                msg = f"Score and eval calls do not match: |{e_score}| != |{score}|"
+                assert abs(e_score) == abs(score), msg
 
             call_sc = inst(**obj)
             assert isinstance(call_sc, float), f"Score is not a float: {call_sc}"
             if inst.get_tag("property:randomness") == "deterministic":
-                msg = f"Score does not match: {c_score} != {call_sc}"
-                assert c_score == call_sc, msg
+                msg = f"Score does not match: {e_score} != {call_sc}"
+                assert e_score == call_sc, msg
 
 
 class OptimizerFixtureGenerator(BaseFixtureGenerator):

--- a/src/hyperactive/tests/test_all_objects.py
+++ b/src/hyperactive/tests/test_all_objects.py
@@ -199,7 +199,7 @@ class TestAllExperiments(ExperimentFixtureGenerator, _QuickTester):
             call_sc = inst(**obj)
             assert isinstance(call_sc, float), f"Score is not a float: {call_sc}"
             if inst.get_tag("property:randomness") == "deterministic":
-                msg = f"Score does not match: {e_score} != {call_sc}"
+                msg = f"Score does not match: {res} != {call_sc}"
                 assert e_score == call_sc, msg
 
 

--- a/src/hyperactive/tests/test_all_objects.py
+++ b/src/hyperactive/tests/test_all_objects.py
@@ -197,7 +197,8 @@ class TestAllExperiments(ExperimentFixtureGenerator, _QuickTester):
             call_sc = inst(**obj)
             assert isinstance(call_sc, float), f"Score is not a float: {call_sc}"
             if inst.get_tag("property:randomness") == "deterministic":
-                assert c_score == call_sc, f"Score does not match: {score} != {call_sc}"
+                msg = f"Score does not match: {c_score} != {call_sc}"
+                assert c_score == call_sc, msg
 
 
 class OptimizerFixtureGenerator(BaseFixtureGenerator):

--- a/src/hyperactive/tests/test_all_objects.py
+++ b/src/hyperactive/tests/test_all_objects.py
@@ -192,7 +192,9 @@ class TestAllExperiments(ExperimentFixtureGenerator, _QuickTester):
             assert isinstance(c_score, float), f"Score is not a float: {c_score}"
             assert isinstance(c_metadata, dict), f"Metadata is not a dict: {c_metadata}"
 
-            assert abs(c_score) == score
+            if inst.get_tag("property:randomness") == "deterministic":
+                msg = f"Score and cost calls do not match: |{c_score}| != |{score}|"
+                assert abs(c_score) == score, msg
 
             call_sc = inst(**obj)
             assert isinstance(call_sc, float), f"Score is not a float: {call_sc}"

--- a/src/hyperactive/tests/test_all_objects.py
+++ b/src/hyperactive/tests/test_all_objects.py
@@ -194,7 +194,7 @@ class TestAllExperiments(ExperimentFixtureGenerator, _QuickTester):
 
             if inst.get_tag("property:randomness") == "deterministic":
                 msg = f"Score and cost calls do not match: |{c_score}| != |{score}|"
-                assert abs(c_score) == score, msg
+                assert abs(c_score) == abs(score), msg
 
             call_sc = inst(**obj)
             assert isinstance(call_sc, float), f"Score is not a float: {call_sc}"


### PR DESCRIPTION
Fixes https://github.com/SimonBlanke/Hyperactive/issues/141 by the following approach:

* adds a tag `property:higher_or_lower_is_better` to experiments to signifiy whether this is minmization or maximization
* ensures the `score` method is always "higher is better"
* moves the extension locus to a new method pair `evaluate` / `_evaluate`, which has the same orientation as the new tag `property:higher_or_lower_is_better`. The `_score` method no longer exists.

The `SklearnCvExperiment` also gets internal functionality to detect the sign from the metric passed. Since metrics in `sklearn` are not tagged properly, there is some clunky detection logic to infer this non-existent tag.

Further changes:

* current experiments are adapted with correct tags `property:higher_or_lower_is_better`
* current `_score` methods are changed to `_evaluate`
* clarifications in extension templates
* clarifications in docstrings

Decision to move to maximization, see discussion in #141.