### PR TITLE
[MNT] raise `scikit-learn` bound to `scikit-learn<1.8`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
 
 [project.optional-dependencies]
 sklearn-integration = [
-  "scikit-learn <1.7.0",
+  "scikit-learn <1.8.0",
 ]
 build = [
   "setuptools",


### PR DESCRIPTION
PR https://github.com/SimonBlanke/Hyperactive/pull/138 added support for `scikit-learn 1.7.X`, but the bound in `pyproject.toml` was not raised - this PR increases that bound.