### PR TITLE
[DOC] fix docstring example in `ForecastingOptCV`

### DIFF
--- a/src/hyperactive/integrations/sktime/_forecasting.py
+++ b/src/hyperactive/integrations/sktime/_forecasting.py
@@ -143,9 +143,9 @@ class ForecastingOptCV(_DelegatedForecaster):
 
     2. fitting the tuned estimator:
     >>> from sktime.datasets import load_airline
-    >>> from sktime.split import train_test_split
+    >>> from sktime.split import temporal_train_test_split
     >>> y = load_airline()
-    >>> y_train, y_test = train_test_split(y, test_size=12)
+    >>> y_train, y_test = temporal_train_test_split(y, test_size=12)
     >>>
     >>> tuned_naive.fit(y_train, fh=range(1, 13))
     ForecastingOptCV(...)

--- a/src/hyperactive/integrations/sktime/_forecasting.py
+++ b/src/hyperactive/integrations/sktime/_forecasting.py
@@ -128,11 +128,18 @@ class ForecastingOptCV(_DelegatedForecaster):
 
     1. defining the tuned estimator:
     >>> from sktime.forecasting.naive import NaiveForecaster
+    >>> from sktime.split import ExpandingWindowSplitter
     >>> from hyperactive.integrations.sktime import ForecastingOptCV
     >>> from hyperactive.opt import GridSearchSk as GridSearch
     >>>
     >>> param_grid = {"strategy": ["mean", "last", "drift"]}
-    >>> tuned_naive = ForecastingOptCV(NaiveForecaster(), GridSearch(param_grid))
+    >>> tuned_naive = ForecastingOptCV(
+    ...     NaiveForecaster(),
+    ...     GridSearch(param_grid),
+    ...     cv=ExpandingWindowSplitter(
+    ...         initial_window=12, step_length=3, fh=range(1, 13)
+    ...     ),
+    ... )
 
     2. fitting the tuned estimator:
     >>> from sktime.datasets import load_airline

--- a/src/hyperactive/integrations/sktime/_forecasting.py
+++ b/src/hyperactive/integrations/sktime/_forecasting.py
@@ -132,7 +132,7 @@ class ForecastingOptCV(_DelegatedForecaster):
     >>> from hyperactive.opt import GridSearchSk as GridSearch
     >>>
     >>> param_grid = {"strategy": ["mean", "last", "drift"]}
-    >>> tuned_naive = ForecastingCV(NaiveForecaster(), GridSearch(param_grid))
+    >>> tuned_naive = ForecastingOptCV(NaiveForecaster(), GridSearch(param_grid))
 
     2. fitting the tuned estimator:
     >>> from sktime.datasets import load_airline

--- a/src/hyperactive/integrations/sktime/_forecasting.py
+++ b/src/hyperactive/integrations/sktime/_forecasting.py
@@ -124,29 +124,29 @@ class ForecastingOptCV(_DelegatedForecaster):
 
     Example
     -------
-    Tuning sklearn SVC via grid search
+    Tuning an sktime forecaster via grid search
 
     1. defining the tuned estimator:
-    >>> from sklearn.svm import SVC
-    >>> from hyperactive.integrations.sklearn import OptCV
+    >>> from sktime.forecasting.naive import NaiveForecaster
+    >>> from hyperactive.integrations.sktime import ForecastingOptCV
     >>> from hyperactive.opt import GridSearchSk as GridSearch
     >>>
-    >>> param_grid = {"kernel": ["linear", "rbf"], "C": [1, 10]}
-    >>> tuned_svc = OptCV(SVC(), GridSearch(param_grid))
+    >>> param_grid = {"strategy": ["mean", "last", "drift"]}
+    >>> tuned_naive = ForecastingCV(NaiveForecaster(), GridSearch(param_grid))
 
     2. fitting the tuned estimator:
-    >>> from sklearn.datasets import load_iris
-    >>> from sklearn.model_selection import train_test_split
-    >>> X, y = load_iris(return_X_y=True)
-    >>> X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2)
+    >>> from sktime.datasets import load_airline
+    >>> from sktime.split import train_test_split
+    >>> y = load_airline()
+    >>> y_train, y_test = train_test_split(y, test_size=12)
     >>>
-    >>> tuned_svc.fit(X_train, y_train)
-    OptCV(...)
-    >>> y_pred = tuned_svc.predict(X_test)
+    >>> tuned_naive.fit(y_train, fh=range(1, 13))
+    ForecastingOptCV(...)
+    >>> y_pred = tuned_naive.predict()
 
     3. obtaining best parameters and best estimator
-    >>> best_params = tuned_svc.best_params_
-    >>> best_estimator = tuned_svc.best_estimator_
+    >>> best_params = tuned_naive.best_params_
+    >>> best_estimator = tuned_naive.best_forecaster_
     """
 
     _tags = {


### PR DESCRIPTION
fixes the docstring example in `ForecastingOptCV`, which accidentally was copy-paste of another estimator, `OptCV`