### PR TITLE
[BUG] fix docstrings of benchmark toy experiments

### DIFF
--- a/src/hyperactive/experiment/bench/_ackley.py
+++ b/src/hyperactive/experiment/bench/_ackley.py
@@ -7,8 +7,6 @@ from hyperactive.base import BaseExperiment
 
 
 class Ackley(BaseExperiment):
-    """Ackley class."""
-
     r"""Ackley function, common benchmark for optimization algorithms.
 
     The Ackley function is a non-convex function used to test optimization algorithms.

--- a/src/hyperactive/experiment/bench/_parabola.py
+++ b/src/hyperactive/experiment/bench/_parabola.py
@@ -5,8 +5,6 @@ from hyperactive.base import BaseExperiment
 
 
 class Parabola(BaseExperiment):
-    """Parabola class."""
-
     r"""2D parabola, common benchmark for optimization algorithms.
 
     Parabola parameterized by the formula:

--- a/src/hyperactive/experiment/bench/_sphere.py
+++ b/src/hyperactive/experiment/bench/_sphere.py
@@ -7,8 +7,6 @@ from hyperactive.base import BaseExperiment
 
 
 class Sphere(BaseExperiment):
-    """Sphere class."""
-
     r"""Simple Sphere function, common benchmark for optimization algorithms.
 
     Sphere function parameterized by the formula:


### PR DESCRIPTION
The docstrings of the benchmark toy experiments got broken accidentally.

Quick merge due to problem on `main`.