### PR TITLE
[DOC] improved docstrings for estimator tuners in integrations module

### DIFF
--- a/src/hyperactive/integrations/sklearn/opt_cv.py
+++ b/src/hyperactive/integrations/sklearn/opt_cv.py
@@ -34,11 +34,14 @@ class OptCV(BaseEstimator, _BestEstimator_, Checks):
 
     Formally, ``OptCV`` does the following:
 
-    In ``fit``, wraps the ``estimator``, ``scoring``, and other parameters
-    into a ``SklearnCvExperiment`` instance, which is passed to the optimizer
-    ``optimizer`` as the ``experiment`` argument.
-    Optimal parameters are then obtained from ``optimizer.solve``, and set
-    as ``best_params_`` and ``best_estimator_`` attributes.
+    In ``fit``:
+
+    * wraps the ``estimator``, ``scoring``, and other parameters
+      into a ``SklearnCvExperiment`` instance, which is passed to the optimizer
+      ``optimizer`` as the ``experiment`` argument.
+    * Optimal parameters are then obtained from ``optimizer.solve``, and set
+      as ``best_params_`` and ``best_estimator_`` attributes.
+    * If ``refit=True``, ``best_estimator_`` is fitted to the entire ``X`` and ``y``.
 
     In ``predict`` and ``predict``-like methods, calls the respective method
     of the ``best_estimator_`` if ``refit=True``.

--- a/src/hyperactive/integrations/sktime/_forecasting.py
+++ b/src/hyperactive/integrations/sktime/_forecasting.py
@@ -33,11 +33,14 @@ class ForecastingOptCV(_DelegatedForecaster):
 
     Formally, ``ForecastingOptCV`` does the following:
 
-    In ``fit``, wraps the ``forecaster``, ``scoring``, and other parameters
-    into a ``SktimeForecastingExperiment`` instance, which is passed to the optimizer
-    ``optimizer`` as the ``experiment`` argument.
-    Optimal parameters are then obtained from ``optimizer.solve``, and set
-    as ``best_params_`` and ``best_forecaster_`` attributes.
+    In ``fit``:
+
+    * wraps the ``forecaster``, ``scoring``, and other parameters
+      into a ``SktimeForecastingExperiment`` instance, which is passed to the optimizer
+      ``optimizer`` as the ``experiment`` argument.
+    * Optimal parameters are then obtained from ``optimizer.solve``, and set
+      as ``best_params_`` and ``best_forecaster_`` attributes.
+    *  If ``refit=True``, ``best_forecaster_`` is fitted to the entire ``y`` and ``X``.
 
     In ``predict`` and ``predict``-like methods, calls the respective method
     of the ``best_forecaster_`` if ``refit=True``.


### PR DESCRIPTION
This PR adds clarification to the documentation of estimator tuners in the `integrations` module.