### PR TITLE
[MNT] temporary skip for test failures impacted by bug in cpython 3.13.7 windows

### DIFF
--- a/src/hyperactive/tests/_config.py
+++ b/src/hyperactive/tests/_config.py
@@ -1,5 +1,15 @@
 """Test configs."""
 
+# todo 5.1: review if skipping is still necessary
+# if not, remove below
+import sys
+import platform
+
+cpython_138031_bug_present = (
+    sys.version_info[:3] == (3, 13, 7) and platform.system() == "Windows"
+)
+# end remove
+
 # list of str, names of estimators to exclude from testing
 # WARNING: tests for these estimators will be skipped
 EXCLUDE_ESTIMATORS = [
@@ -10,4 +20,15 @@ EXCLUDE_ESTIMATORS = [
 # dictionary of lists of str, names of tests to exclude from testing
 # keys are class names of estimators, values are lists of test names to exclude
 # WARNING: tests with these names will be skipped
-EXCLUDED_TESTS = {}
+
+# cpython bug #138031 causes random test failures on Windows with Python 3.13.7
+# see https://github.com/SimonBlanke/Hyperactive/issues/169
+# todo 5.1: review if this skipping is still necessary
+# if no longer necessary, remove the "if" condition and leave the "else" part
+if cpython_138031_bug_present:
+    EXCLUDED_TESTS = {
+        "GridSearchSK": ["test_opt_run"],
+        "RandomSearchSK": ["test_opt_run"],
+    }
+else:
+    EXCLUDED_TESTS = {}

--- a/src/hyperactive/utils/parallel.py
+++ b/src/hyperactive/utils/parallel.py
@@ -224,6 +224,20 @@ SKIP_FIXTURES = [
     "ray",  # unstable, sporadic crashes in CI, see bug 8149
 ]
 
+# todo 5.1: review if skipping is still necessary
+# if not, remove below
+import sys
+import platform
+
+cpython_138031_bug_present = (
+    sys.version_info[:3] == (3, 13, 7) and platform.system() == "Windows"
+)
+
+if cpython_138031_bug_present:
+    SKIP_FIXTURES.append("loky")
+    SKIP_FIXTURES.append("multiprocessing")
+# end remove
+
 
 def _get_parallel_test_fixtures(naming="estimator"):
     """Return fixtures for parallelization tests.


### PR DESCRIPTION
Temporary skip for tests impacted by the cpython bug under python 3.137 and windows, see
https://github.com/SimonBlanke/Hyperactive/issues/169

The skips should be removed once #169 is resolved - does not resolve #169, only skips tests.