### PR TITLE
[BUG] fix `params` ignored in `SktimeForecastingExperiment`

### DIFF
--- a/src/hyperactive/experiment/integrations/sktime_forecasting.py
+++ b/src/hyperactive/experiment/integrations/sktime_forecasting.py
@@ -210,8 +210,10 @@ class SktimeForecastingExperiment(BaseExperiment):
         """
         from sktime.forecasting.model_evaluation import evaluate
 
+        forecaster = self.forecaster.clone().set_params(**params)
+
         results = evaluate(
-            self.forecaster,
+            forecaster,
             cv=self.cv,
             y=self.y,
             X=self.X,


### PR DESCRIPTION
fixes an unreported bug where the `params` in `_evaluate` were ignored, in `SktimeForecastingExperiment`.

This is fixed by cloning `forecaster` and setting the parameters.