### PR TITLE
[ENH] experiments: uniform call signature and terminology

### DIFF
--- a/examples/optuna/gp_sampler_example.py
+++ b/examples/optuna/gp_sampler_example.py
@@ -14,10 +14,8 @@ Characteristics:
 - Can handle constraints and noisy observations
 """
 
-import numpy as np
 from sklearn.datasets import load_breast_cancer
 from sklearn.svm import SVC
-from sklearn.model_selection import cross_val_score
 
 from hyperactive.experiment.integrations import SklearnCvExperiment
 from hyperactive.opt.optuna import GPOptimizer

--- a/examples/optuna/grid_sampler_example.py
+++ b/examples/optuna/grid_sampler_example.py
@@ -14,10 +14,8 @@ Characteristics:
 - Interpretable and deterministic results
 """
 
-import numpy as np
 from sklearn.datasets import load_iris
 from sklearn.neighbors import KNeighborsClassifier
-from sklearn.model_selection import cross_val_score
 
 from hyperactive.experiment.integrations import SklearnCvExperiment
 from hyperactive.opt.optuna import GridOptimizer

--- a/examples/optuna/nsga_ii_sampler_example.py
+++ b/examples/optuna/nsga_ii_sampler_example.py
@@ -33,7 +33,7 @@ class MultiObjectiveExperiment:
         self.X = X
         self.y = y
 
-    def __call__(self, **params):
+    def __call__(self, params):
         # Create model with parameters
         model = RandomForestClassifier(random_state=42, **params)
 

--- a/examples/optuna/nsga_iii_sampler_example.py
+++ b/examples/optuna/nsga_iii_sampler_example.py
@@ -34,7 +34,7 @@ class ManyObjectiveExperiment:
         self.X = X
         self.y = y
 
-    def __call__(self, **params):
+    def __call__(self, params):
         # Create model with parameters
         model = DecisionTreeClassifier(random_state=42, **params)
 

--- a/examples/optuna/qmc_sampler_example.py
+++ b/examples/optuna/qmc_sampler_example.py
@@ -19,10 +19,8 @@ QMC sequences are particularly effective for:
 - Baseline optimization comparisons
 """
 
-import numpy as np
 from sklearn.datasets import load_wine
 from sklearn.linear_model import LogisticRegression
-from sklearn.model_selection import cross_val_score
 
 from hyperactive.experiment.integrations import SklearnCvExperiment
 from hyperactive.opt.optuna import QMCOptimizer

--- a/examples/optuna/random_sampler_example.py
+++ b/examples/optuna/random_sampler_example.py
@@ -15,10 +15,8 @@ Characteristics:
 - Good when objective function is noisy
 """
 
-import numpy as np
 from sklearn.datasets import load_digits
 from sklearn.svm import SVC
-from sklearn.model_selection import cross_val_score
 
 from hyperactive.experiment.integrations import SklearnCvExperiment
 from hyperactive.opt.optuna import RandomOptimizer

--- a/examples/optuna/tpe_sampler_example.py
+++ b/examples/optuna/tpe_sampler_example.py
@@ -13,10 +13,8 @@ Characteristics:
 - Default choice for most hyperparameter optimization tasks
 """
 
-import numpy as np
 from sklearn.datasets import load_wine
 from sklearn.ensemble import RandomForestClassifier
-from sklearn.model_selection import cross_val_score
 
 from hyperactive.experiment.integrations import SklearnCvExperiment
 from hyperactive.opt.optuna import TPEOptimizer

--- a/src/hyperactive/base/_experiment.py
+++ b/src/hyperactive/base/_experiment.py
@@ -21,9 +21,9 @@ class BaseExperiment(BaseObject):
     def __init__(self):
         super().__init__()
 
-    def __call__(self, kwargs):
+    def __call__(self, params):
         """Score parameters. Same as score call, returns only only a first element."""
-        score, _ = self.score(kwargs)
+        score, _ = self.score(params)
         return score
 
     @property

--- a/src/hyperactive/base/_experiment.py
+++ b/src/hyperactive/base/_experiment.py
@@ -21,8 +21,8 @@ class BaseExperiment(BaseObject):
     def __init__(self):
         super().__init__()
 
-    def __call__(self, **kwargs):
-        """Score parameters, with kwargs call. Same as score call."""
+    def __call__(self, kwargs):
+        """Score parameters. Same as score call, returns only only a first element."""
         score, _ = self.score(kwargs)
         return score
 

--- a/src/hyperactive/experiment/bench/_ackley.py
+++ b/src/hyperactive/experiment/bench/_ackley.py
@@ -39,10 +39,10 @@ class Ackley(BaseExperiment):
     >>> from hyperactive.experiment.bench import Ackley
     >>> ackley = Ackley(a=20)
     >>> params = {"x0": 1, "x1": 2}
-    >>> score, add_info = ackley.score(params)
+    >>> score, metadata = ackley.score(params)
 
     Quick call without metadata return or dictionary:
-    >>> score = ackley(x0=1, x1=2)
+    >>> score = ackley({"x0": 1, "x1": 2})
     """  # noqa: E501
 
     _tags = {

--- a/src/hyperactive/experiment/bench/_parabola.py
+++ b/src/hyperactive/experiment/bench/_parabola.py
@@ -33,10 +33,10 @@ class Parabola(BaseExperiment):
     >>> from hyperactive.experiment.bench import Parabola
     >>> parabola = Parabola(a=1.0, b=0.0, c=0.0)
     >>> params = {"x": 1, "y": 2}
-    >>> score, add_info = parabola.score(params)
+    >>> score, metadata = parabola.score(params)
 
     Quick call without metadata return or dictionary:
-    >>> score = parabola(x=1, y=2)
+    >>> score = parabola({"x": 1, "y": 2})
     """
 
     _tags = {

--- a/src/hyperactive/experiment/bench/_sphere.py
+++ b/src/hyperactive/experiment/bench/_sphere.py
@@ -36,14 +36,14 @@ class Sphere(BaseExperiment):
     >>> from hyperactive.experiment.bench import Sphere
     >>> sphere = Sphere(const=0, n_dim=3)
     >>> params = {"x0": 1, "x1": 2, "x2": 3}
-    >>> score, add_info = sphere.score(params)
+    >>> score, metadata = sphere.score(params)
 
     Quick call without metadata return or dictionary:
-    >>> score = sphere(x0=1, x1=2, x2=3)
+    >>> score = sphere({"x0": 1, "x1": 2, "x2": 3})
 
     Different number of dimensions changes the parameter names:
     >>> sphere4D = Sphere(const=0, n_dim=4)
-    >>> score4D = sphere4D(x0=1, x1=2, x2=3, x3=4)
+    >>> score4D = sphere4D({"x0": 1, "x1": 2, "x2": 3, "x3": 4})
     """
 
     _tags = {

--- a/src/hyperactive/experiment/integrations/sklearn_cv.py
+++ b/src/hyperactive/experiment/integrations/sklearn_cv.py
@@ -62,7 +62,7 @@ class SklearnCvExperiment(BaseExperiment):
     ...     y=y,
     ... )
     >>> params = {"C": 1.0, "kernel": "linear"}
-    >>> score, add_info = sklearn_exp.score(params)
+    >>> score, metadata = sklearn_exp.score(params)
 
     For default choices of ``scoring`` and ``cv``:
     >>> sklearn_exp = SklearnCvExperiment(
@@ -71,10 +71,10 @@ class SklearnCvExperiment(BaseExperiment):
     ...     y=y,
     ... )
     >>> params = {"C": 1.0, "kernel": "linear"}
-    >>> score, add_info = sklearn_exp.score(params)
+    >>> score, metadata = sklearn_exp.score(params)
 
     Quick call without metadata return or dictionary:
-    >>> score = sklearn_exp(C=1.0, kernel="linear")
+    >>> score = sklearn_exp({"C": 1.0, "kernel": "linear"})
     """
 
     def __init__(self, estimator, X, y, scoring=None, cv=None):
@@ -158,13 +158,13 @@ class SklearnCvExperiment(BaseExperiment):
             cv=self._cv,
         )
 
-        add_info_d = {
+        metadata = {
             "score_time": cv_results["score_time"],
             "fit_time": cv_results["fit_time"],
             "n_test_samples": _num_samples(self.X),
         }
 
-        return cv_results["test_score"].mean(), add_info_d
+        return cv_results["test_score"].mean(), metadata
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/src/hyperactive/experiment/integrations/sktime_forecasting.py
+++ b/src/hyperactive/experiment/integrations/sktime_forecasting.py
@@ -121,7 +121,7 @@ class SktimeForecastingExperiment(BaseExperiment):
     ...     y=y,
     ... )
     >>> params = {"strategy": "mean"}
-    >>> score, add_info = sktime_exp.score(params)
+    >>> score, metadata = sktime_exp.score(params)
 
     For default choices of ``scoring``:
     >>> sktime_exp = SktimeForecastingExperiment(
@@ -130,10 +130,10 @@ class SktimeForecastingExperiment(BaseExperiment):
     ...     y=y,
     ... )
     >>> params = {"strategy": "mean"}
-    >>> score, add_info = sktime_exp.score(params)
+    >>> score, metadata = sktime_exp.score(params)
 
     Quick call without metadata return or dictionary:
-    >>> score = sktime_exp(strategy="mean")
+    >>> score = sktime_exp({"strategy": "mean"})
     """
 
     _tags = {

--- a/src/hyperactive/opt/_adapters/_base_optuna_adapter.py
+++ b/src/hyperactive/opt/_adapters/_base_optuna_adapter.py
@@ -110,7 +110,7 @@ class _BaseOptunaAdapter(BaseOptimizer):
             The objective value
         """
         params = self._suggest_params(trial, self.param_space)
-        score = self.experiment.score(params)
+        score = self.experiment(params)
 
         # Handle early stopping based on max_score
         if self.max_score is not None and score >= self.max_score:

--- a/src/hyperactive/opt/_adapters/_base_optuna_adapter.py
+++ b/src/hyperactive/opt/_adapters/_base_optuna_adapter.py
@@ -133,7 +133,7 @@ class _BaseOptunaAdapter(BaseOptimizer):
                     # For warm start, we manually add trials to the study history
                     # instead of using suggest methods to avoid distribution conflicts
                     for point in warm_start_points:
-                        self.experiment(**point)
+                        self.experiment(point)
                         study.enqueue_trial(point)
 
     def _solve(self, experiment, param_space, n_trials, **kwargs):

--- a/src/hyperactive/opt/_adapters/_base_optuna_adapter.py
+++ b/src/hyperactive/opt/_adapters/_base_optuna_adapter.py
@@ -110,7 +110,7 @@ class _BaseOptunaAdapter(BaseOptimizer):
             The objective value
         """
         params = self._suggest_params(trial, self.param_space)
-        score = self.experiment(**params)
+        score = self.experiment.score(params)
 
         # Handle early stopping based on max_score
         if self.max_score is not None and score >= self.max_score:

--- a/src/hyperactive/tests/test_all_objects.py
+++ b/src/hyperactive/tests/test_all_objects.py
@@ -225,7 +225,7 @@ class TestAllExperiments(ExperimentFixtureGenerator, _QuickTester):
                 msg = f"Score and eval calls do not match: |{e_score}| != |{score}|"
                 assert abs(e_score) == abs(score), msg
 
-            call_sc = inst(**obj)
+            call_sc = inst(obj)
             assert isinstance(call_sc, float), f"Score is not a float: {call_sc}"
             if det_tag == "deterministic":
                 msg = f"Score does not match: {score} != {call_sc}"


### PR DESCRIPTION
In `BaseExperiment` descendants, makes the following consistent:

* `__call__` signature is now `__call__(params)`, instead of `__call__(**params)` - for consistency with `evaluate` and the expected function/callable interface
* the second return of `score` and `evaluate` is now consistently called "metadata" (instead of `add_info`), as referred to in the docstrings

Minor additional changes:

* removed some unused imports