### PR TITLE
[MNT] release workflow for pypi release after GitHub release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,141 @@
+name: Build wheels and release on PyPI
+# This workflow is triggered when a new release tag is published on GitHub.
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  check_tag:
+    name: Check tag
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - shell: bash
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          GH_TAG_NAME="${TAG#v}"
+          PY_VERSION=$(python - <<'PY'
+          import pathlib, tomllib
+          data = tomllib.loads(pathlib.Path("pyproject.toml").read_text(encoding="utf-8"))
+          print(data.get("project").get("version"))
+          PY
+          )
+          if [ "${GH_TAG_NAME}" != "${PY_VERSION}" ]; then
+            echo "::error::Tag (${GH_TAG_NAME}) does not match pyproject.toml version (${PY_VERSION})."
+            exit 2
+          fi
+
+  build_wheels:
+    needs: check_tag
+    name: Build wheels
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+
+      - name: Build wheel
+        run: |
+          python -m pip install build
+          python -m build --wheel --sdist --outdir wheelhouse
+
+      - name: Store wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels
+          path: wheelhouse/*
+
+  test_unix_wheels:
+    needs: build_wheels
+    name: Test wheels on ${{ matrix.os }} with ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false  # to not fail all combinations if just one fail
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - uses: actions/download-artifact@v5
+        with:
+          name: wheels
+          path: wheelhouse
+
+      - name: Display downloaded artifacts
+        run: ls -l wheelhouse
+
+      - name: Get wheel filename
+        run: echo "WHEELNAME=$(ls ./wheelhouse/hyperactive-*none-any.whl)" >> $GITHUB_ENV
+
+      - name: Install wheel and extras
+        run: python -m pip install "${{ env.WHEELNAME }}[all_extras,test]"
+
+      - name: Run tests
+        run: make test_without_datasets
+
+  test_windows_wheels:
+    needs: build_wheels
+    name: Test wheels on ${{ matrix.os }} with ${{ matrix.python-version }}
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false  # to not fail all combinations if just one fail
+      matrix:
+        os: [windows-latest]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - uses: actions/download-artifact@v5
+        with:
+          name: wheels
+          path: wheelhouse
+
+      - name: Display downloaded artifacts
+        run: ls -l wheelhouse
+
+      - name: Get wheel filename
+        run: echo "WHEELNAME=$(ls ./wheelhouse/hyperactive-*none-any.whl)" >> $env:GITHUB_ENV
+
+      - name: Install wheel and extras
+        run: python -m pip install "${env:WHEELNAME}[all_extras,test]"
+
+      - name: Run tests  # explicit commands as windows does not support make
+        run: python -m pytest
+
+  upload_wheels:
+    name: Upload wheels to PyPI
+    runs-on: ubuntu-latest
+    needs: [build_wheels,test_unix_wheels,test_windows_wheels]
+
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: actions/download-artifact@v5
+        with:
+          name: wheels
+          path: wheelhouse
+
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: wheelhouse/


### PR DESCRIPTION
Fixes #188, adds a release workflow for pypi release after GitHub release tag