### PR TITLE
[ENH] Add categorical feature encoding for GFO adapters

### DIFF
--- a/src/hyperactive/opt/_adapters/_gfo.py
+++ b/src/hyperactive/opt/_adapters/_gfo.py
@@ -99,6 +99,10 @@ class _BaseGFOadapter(BaseOptimizer):
         returning ``best_params_``. A dimension is treated as categorical if
         its dtype is non-numeric (string, object, or boolean).
 
+        Note: ``np.unique`` sorts values, so the encoding is not order-preserving.
+        For example, ``["rbf", "linear"]`` becomes ``["linear", "rbf"]`` with
+        indices ``[1, 0]}``.
+
         Parameters
         ----------
         search_space : dict with str keys and iterable values
@@ -185,7 +189,8 @@ class _BaseGFOadapter(BaseOptimizer):
 
         def _objective(params):
             decoded_params = self._decode_categoricals(params)
-            return experiment.score(decoded_params)
+            score, _ = experiment.score(decoded_params)
+            return score
 
         with StdoutMute(active=not self.verbose):
             gfopt.search(

--- a/src/hyperactive/tests/test_all_objects.py
+++ b/src/hyperactive/tests/test_all_objects.py
@@ -14,7 +14,6 @@ from hyperactive.tests._doctest import run_doctest
 # default is False, can be set to True by pytest --only_changed_modules True flag
 ONLY_CHANGED_MODULES = False
 
-
 class PackageConfig:
     """Contains package config variables for test classes."""
 
@@ -53,7 +52,6 @@ class PackageConfig:
         # capabilities
         "capability:categorical",
     ]
-
 
 class BaseFixtureGenerator(PackageConfig, _BaseFixtureGenerator):
     """Fixture generator for base testing functionality in sktime.
@@ -136,7 +134,6 @@ class BaseFixtureGenerator(PackageConfig, _BaseFixtureGenerator):
     # which sequence the conditional fixtures are generated in
     fixture_sequence = ["object_class", "object_instance"]
 
-
 class TestAllObjects(BaseFixtureGenerator, _TestAllObjects):
     """Generic tests for all objects in the package."""
 
@@ -169,7 +166,6 @@ class TestAllObjects(BaseFixtureGenerator, _TestAllObjects):
 
         super().test_valid_object_class_tags(object_instance)
 
-
 class ExperimentFixtureGenerator(BaseFixtureGenerator):
     """Fixture generator for experiments.
 
@@ -183,7 +179,6 @@ class ExperimentFixtureGenerator(BaseFixtureGenerator):
     """
 
     object_type_filter = "experiment"
-
 
 class TestAllExperiments(ExperimentFixtureGenerator, _QuickTester):
     """Module level tests for all experiment classes."""
@@ -240,7 +235,6 @@ class TestAllExperiments(ExperimentFixtureGenerator, _QuickTester):
             elif sign_tag == "lower" and det_tag == "deterministic":
                 assert score == -e_score
 
-
 class OptimizerFixtureGenerator(BaseFixtureGenerator):
     """Fixture generator for optimizers.
 
@@ -254,7 +248,6 @@ class OptimizerFixtureGenerator(BaseFixtureGenerator):
     """
 
     object_type_filter = "optimizer"
-
 
 class TestAllOptimizers(OptimizerFixtureGenerator, _QuickTester):
     """Module level tests for all optimizer classes."""
@@ -384,6 +377,10 @@ class TestAllOptimizers(OptimizerFixtureGenerator, _QuickTester):
         assert "kernel" in best_params
         assert best_params["kernel"] in {"linear", "rbf"}
 
+        # Verify internal categorical mappings were populated correctly
+        assert "kernel" in optimizer._categorical_mappings
+        assert set(optimizer._categorical_mappings["kernel"]) == {"linear", "rbf"}
+
     def test_selection_direction_backend(self, object_instance):
         """Backends return argmax over standardized scores on controlled setup.
 
@@ -497,3 +494,4 @@ class TestAllOptimizers(OptimizerFixtureGenerator, _QuickTester):
 
         # For other backends, no-op here; targeted direction tests live elsewhere
         return None
+


### PR DESCRIPTION
To Resolve #136 
This PR adds automatic categorical feature handling for GFO-based optimizers by encoding non-numeric search space dimensions to consecutive integers internally, then decoding them back when evaluating the objective and returning results.
Changes:

1. Categorical dimensions (detected via dtype: object, unicode, string, boolean) are encoded to consecutive integers using `np.unique`
2. Original category mappings are stored in `_categorical_mappings` for decoding
3. Decoding happens transparently during objective evaluation and when returning `best_params_`
4. Numeric dimensions are left unchanged
5. Added `capability:categorical` tag with value "encoded" to` _BaseGFOadapter`
6. Added test covering mixed numeric/categorical search spaces

