### PR TITLE
Fix #213: Add metadata to TorchExperiment._evaluate() method

### DIFF
--- a/src/hyperactive/experiment/integrations/torch_lightning_experiment.py
+++ b/src/hyperactive/experiment/integrations/torch_lightning_experiment.py
@@ -177,7 +177,10 @@ class TorchExperiment(BaseExperiment):
             trainer.fit(model, self.datamodule)
 
             val_result = trainer.callback_metrics.get(self.objective_metric)
-            metadata = {}
+            metadata = {= {
+            "num_epochs_trained": trainer.current_epoch,
+            "all_metrics": trainer.callback_metrics,
+        }
 
             if val_result is None:
                 available_metrics = list(trainer.callback_metrics.keys())


### PR DESCRIPTION
The metadata dictionary in TorchExperiment._evaluate() was always empty. This fix populates it with useful training information:
- num_epochs_trained: The number of epochs the model was trained for
- all_metrics: All metrics collected during training

This is consistent with other Hyperactive integrations (sklearn, sktime) which also return useful metadata.