### PR TITLE
[DOC] Add docstrings for `best_estimator.py`

### DIFF
--- a/src/hyperactive/integrations/sklearn/best_estimator.py
+++ b/src/hyperactive/integrations/sklearn/best_estimator.py
@@ -25,8 +25,6 @@ class BestEstimator:
         Only available if ``refit=True`` and the underlying estimator supports
         ``score_samples``.
 
-        .. versionadded:: 0.24
-
         Parameters
         ----------
         X : iterable
@@ -36,7 +34,8 @@ class BestEstimator:
         Returns
         -------
         y_score : ndarray of shape (n_samples,)
-            The ``best_estimator_.score_samples`` method.
+            Score per sample for `X` based on the estimator with the best found
+            parameters (e.g. log-likelihood, anomaly score).
         """
         check_is_fitted(self)
         return self.best_estimator_.score_samples(X)
@@ -164,8 +163,11 @@ class BestEstimator:
         Parameters
         ----------
         X : indexable, length n_samples
-            Must fulfill the input assumptions of the
-            underlying estimator.
+            Data in the transformed space. Must fulfill the input assumptions
+            of the underlying estimator.
+        Xt : array-like of shape (n_samples, n_features), optional
+            Deprecated in scikit-learn 1.2 and removed in 1.7. Use ``X``
+            instead. The former parameter name for the transformed data.
 
         Returns
         -------

--- a/src/hyperactive/integrations/sklearn/best_estimator.py
+++ b/src/hyperactive/integrations/sklearn/best_estimator.py
@@ -20,43 +20,159 @@ class BestEstimator:
 
     @available_if(_estimator_has("score_samples"))
     def score_samples(self, X):
-        """Score Samples function."""
+        """Call score_samples on the estimator with the best found parameters.
+
+        Only available if ``refit=True`` and the underlying estimator supports
+        ``score_samples``.
+
+        .. versionadded:: 0.24
+
+        Parameters
+        ----------
+        X : iterable
+            Data to predict on. Must fulfill input requirements
+            of the underlying estimator.
+
+        Returns
+        -------
+        y_score : ndarray of shape (n_samples,)
+            The ``best_estimator_.score_samples`` method.
+        """
         check_is_fitted(self)
         return self.best_estimator_.score_samples(X)
 
     @available_if(_estimator_has("predict"))
     def predict(self, X):
-        """Predict function."""
+        """Call predict on the estimator with the best found parameters.
+
+        Only available if ``refit=True`` and the underlying estimator supports
+        ``predict``.
+
+        Parameters
+        ----------
+        X : indexable, length n_samples
+            Must fulfill the input assumptions of the
+            underlying estimator.
+
+        Returns
+        -------
+        y_pred : ndarray of shape (n_samples,)
+            The predicted labels or values for `X` based on the estimator with
+            the best found parameters.
+        """
         check_is_fitted(self)
         return self.best_estimator_.predict(X)
 
     @available_if(_estimator_has("predict_proba"))
     def predict_proba(self, X):
-        """Predict Proba function."""
+        """Call predict_proba on the estimator with the best found parameters.
+
+        Only available if ``refit=True`` and the underlying estimator supports
+        ``predict_proba``.
+
+        Parameters
+        ----------
+        X : indexable, length n_samples
+            Must fulfill the input assumptions of the
+            underlying estimator.
+
+        Returns
+        -------
+        y_pred : ndarray of shape (n_samples,) or (n_samples, n_classes)
+            Predicted class probabilities for `X` based on the estimator with
+            the best found parameters. The order of the classes corresponds
+            to that in the fitted attribute :term:`classes_`.
+        """
         check_is_fitted(self)
         return self.best_estimator_.predict_proba(X)
 
     @available_if(_estimator_has("predict_log_proba"))
     def predict_log_proba(self, X):
-        """Predict Log Proba function."""
+        """Call predict_log_proba on the estimator with the best found parameters.
+
+        Only available if ``refit=True`` and the underlying estimator supports
+        ``predict_log_proba``.
+
+        Parameters
+        ----------
+        X : indexable, length n_samples
+            Must fulfill the input assumptions of the
+            underlying estimator.
+
+        Returns
+        -------
+        y_pred : ndarray of shape (n_samples,) or (n_samples, n_classes)
+            Predicted class log-probabilities for `X` based on the estimator
+            with the best found parameters. The order of the classes
+            corresponds to that in the fitted attribute :term:`classes_`.
+        """
         check_is_fitted(self)
         return self.best_estimator_.predict_log_proba(X)
 
     @available_if(_estimator_has("decision_function"))
     def decision_function(self, X):
-        """Decision Function function."""
+        """Call decision_function on the estimator with the best found parameters.
+
+        Only available if ``refit=True`` and the underlying estimator supports
+        ``decision_function``.
+
+        Parameters
+        ----------
+        X : indexable, length n_samples
+            Must fulfill the input assumptions of the
+            underlying estimator.
+
+        Returns
+        -------
+        y_score : ndarray of shape (n_samples,) or (n_samples, n_classes) \
+                or (n_samples, n_classes * (n_classes-1) / 2)
+            Result of the decision function for `X` based on the estimator with
+            the best found parameters.
+        """
         check_is_fitted(self)
         return self.best_estimator_.decision_function(X)
 
     @available_if(_estimator_has("transform"))
     def transform(self, X):
-        """Transform function."""
+        """Call transform on the estimator with the best found parameters.
+
+        Only available if the underlying estimator supports ``transform`` and
+        ``refit=True``.
+
+        Parameters
+        ----------
+        X : indexable, length n_samples
+            Must fulfill the input assumptions of the
+            underlying estimator.
+
+        Returns
+        -------
+        Xt : {ndarray, sparse matrix} of shape (n_samples, n_features)
+            `X` transformed in the new space based on the estimator with
+            the best found parameters.
+        """
         check_is_fitted(self)
         return self.best_estimator_.transform(X)
 
     @available_if(_estimator_has("inverse_transform"))
     def inverse_transform(self, X=None, Xt=None):
-        """Inverse Transform function."""
+        """Call inverse_transform on the estimator with the best found params.
+
+        Only available if the underlying estimator implements
+        ``inverse_transform`` and ``refit=True``.
+
+        Parameters
+        ----------
+        X : indexable, length n_samples
+            Must fulfill the input assumptions of the
+            underlying estimator.
+
+        Returns
+        -------
+        X_original : {ndarray, sparse matrix} of shape (n_samples, n_features)
+            Result of the `inverse_transform` function for `X` based on the
+            estimator with the best found parameters.
+        """
         X = _deprecate_Xt_in_inverse_transform(X, Xt)
         check_is_fitted(self)
         return self.best_estimator_.inverse_transform(X)


### PR DESCRIPTION
## Description
This PR adds docstrings for `best_estimator.py`, from https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/model_selection/_search.py
## Related Issues

Fixes #226
## Type of Change

<!-- Mark the applicable option with [x] -->

- [ ] `[BUG]` - Bug fix (non-breaking change fixing an issue)
- [ ] `[ENH]` - New feature (non-breaking change adding functionality)
- [x] `[DOC]` - Documentation changes
- [ ] `[MNT]` - Maintenance

## How was this solved?

<!-- Explain your approach to solving the issue -->

## Checklist

- [x] PR title includes appropriate tag: `[BUG]`, `[ENH]`, `[DOC]` or `[MNT]`
- [x] Linked to related issue (if applicable)
- [ ] Code passes `make check` (lint, format, isort)

## Note
@SimonBlanke `make check` is failing because of unused imports, unorganized imports and other issues... Can I take that up too?   
```
Found 90 errors.
[*] 67 fixable with the `--fix` option (1 hidden fix can be enabled with the `--unsafe-fixes` option).
make: *** [lint] Error 1

```